### PR TITLE
Use $RUNNER_TOOL_CACHE for GitHub images to install Python

### DIFF
--- a/installers/win-setup-template.ps1
+++ b/installers/win-setup-template.ps1
@@ -85,6 +85,11 @@ function Get-ExecParams {
     }
 }
 
+$ToolcacheRoot = $env:AGENT_TOOLSDIRECTORY
+if ([string]::IsNullOrEmpty($ToolcacheRoot)) {
+    # GitHub images don't have `AGENT_TOOLSDIRECTORY` variable
+    $ToolcacheRoot = $env:RUNNER_TOOL_CACHE
+}
 $PythonToolcachePath = Join-Path -Path $env:AGENT_TOOLSDIRECTORY -ChildPath "Python"
 $PythonVersionPath = Join-Path -Path $PythonToolcachePath -ChildPath $Version.ToString()
 $PythonArchPath = Join-Path -Path $PythonVersionPath -ChildPath $Architecture

--- a/installers/win-setup-template.ps1
+++ b/installers/win-setup-template.ps1
@@ -90,7 +90,7 @@ if ([string]::IsNullOrEmpty($ToolcacheRoot)) {
     # GitHub images don't have `AGENT_TOOLSDIRECTORY` variable
     $ToolcacheRoot = $env:RUNNER_TOOL_CACHE
 }
-$PythonToolcachePath = Join-Path -Path $env:AGENT_TOOLSDIRECTORY -ChildPath "Python"
+$PythonToolcachePath = Join-Path -Path $ToolcacheRoot -ChildPath "Python"
 $PythonVersionPath = Join-Path -Path $PythonToolcachePath -ChildPath $Version.ToString()
 $PythonArchPath = Join-Path -Path $PythonVersionPath -ChildPath $Architecture
 


### PR DESCRIPTION
`$env:AGENT_TOOLSDIRECTORY` is not available on GitHub images. Instead,  `$env:RUNNER_TOOL_CACHE` should be used.