### PR TITLE
Clean up additional registry branches when uninstalling Python on Windows

### DIFF
--- a/installers/win-setup-template.ps1
+++ b/installers/win-setup-template.ps1
@@ -21,7 +21,11 @@ function Remove-RegistryEntries
     {
         "Python $MajorVersion.$MinorVersion.*($archFilter)"
     }
-    
+
+    Write-Host "------------------------------------"
+    Get-ChildItem "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Products" -Recurse | Where-Object Property -CContains DisplayName | Where-Object { $_.getValue("DisplayName") -match "Python*" } | ForEach-Object { Write-Host $_.getValue("DisplayName") }
+    Write-Host "------------------------------------"
+
     $regPath = "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Products"
     $regKeys = Get-ChildItem -Path Registry::$regPath -Recurse | Where-Object Property -Ccontains DisplayName
     $regKeys | Where-Object { $_.getValue("DisplayName") -match $versionFilter } | ForEach-Object {
@@ -43,7 +47,6 @@ function Remove-RegistryEntries
         Remove-Item Registry::$_ -Recurse -Force -Verbose
     }
 
-    Write-Host "debug"
     $regPath = "HKEY_LOCAL_MACHINE\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall"
     Get-ChildItem -Path Registry::$regPath | ForEach-Object {
         $dn = $_.getValue("DisplayName")

--- a/installers/win-setup-template.ps1
+++ b/installers/win-setup-template.ps1
@@ -106,11 +106,7 @@ $InstalledVersion = Get-ChildItem -Path $PythonToolcachePath -Filter "$MajorVers
 Write-Host "Remove registry entries for Python ${MajorVersion}.${MinorVersion}(${Architecture})..."
 Remove-RegistryEntries -Architecture $Architecture -MajorVersion $MajorVersion -MinorVersion $MinorVersion
 
-Write-Host $InstalledVersion
-Write-Host $InstalledVersion.Fullname
-Test-Path $InstalledVersion
-Test-Path $InstalledVersion.FullName
-if (($null -ne $InstalledVersion) -and (Test-Path $InstalledVersion)) {
+if (($null -ne $InstalledVersion) -and (Test-Path -Path $InstalledVersion.FullName)) {
     Write-Host "Python$MajorVersion.$MinorVersion was found in $PythonToolcachePath"
     Write-Host "Deleting $($InstalledVersion.FullName)..."
     Remove-Item -Path $InstalledVersion.FullName -Recurse -Force

--- a/installers/win-setup-template.ps1
+++ b/installers/win-setup-template.ps1
@@ -106,6 +106,10 @@ $InstalledVersion = Get-ChildItem -Path $PythonToolcachePath -Filter "$MajorVers
 Write-Host "Remove registry entries for Python ${MajorVersion}.${MinorVersion}(${Architecture})..."
 Remove-RegistryEntries -Architecture $Architecture -MajorVersion $MajorVersion -MinorVersion $MinorVersion
 
+Write-Host $InstalledVersion
+Write-Host $InstalledVersion.Fullname
+Test-Path $InstalledVersion
+Test-Path $InstalledVersion.FullName
 if (($null -ne $InstalledVersion) -and (Test-Path $InstalledVersion)) {
     Write-Host "Python$MajorVersion.$MinorVersion was found in $PythonToolcachePath"
     Write-Host "Deleting $($InstalledVersion.FullName)..."

--- a/installers/win-setup-template.ps1
+++ b/installers/win-setup-template.ps1
@@ -6,7 +6,8 @@ function Get-RegistryVersionFilter {
     param
     (
         [Parameter(Mandatory)][String] $Architecture,
-        [Parameter(Mandatory)][Int32] $MajorVersion
+        [Parameter(Mandatory)][Int32] $MajorVersion,
+        [Parameter(Mandatory)][Int32] $MinorVersion
     )
 
     $archFilter = if ($Architecture -eq 'x86') { "32-bit" } else { "64-bit" }
@@ -30,7 +31,7 @@ function Remove-RegistryEntries
         [Parameter(Mandatory)][Int32] $MinorVersion
     )
 
-    $versionFilter = Get-RegistryVersionFilter -Architecture $Architecture -MajorVersion $MajorVersion
+    $versionFilter = Get-RegistryVersionFilter -Architecture $Architecture -MajorVersion $MajorVersion -MinorVersion $MinorVersion
 
     $regPath = "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Products"
     $regKeys = Get-ChildItem -Path Registry::$regPath -Recurse | Where-Object Property -Ccontains DisplayName

--- a/installers/win-setup-template.ps1
+++ b/installers/win-setup-template.ps1
@@ -36,7 +36,7 @@ function Remove-RegistryEntries
         Remove-Item Registry::$_ -Recurse -Force -Verbose
     }
 
-    $regPath = "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Uninstall"
+    $regPath = "HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Uninstall"
     Get-ChildItem -Path Registry::$regPath | ForEach-Object {
         $pn = $_.GetValue("ProductName")
         $dn = $_.getValue("DisplayName")

--- a/installers/win-setup-template.ps1
+++ b/installers/win-setup-template.ps1
@@ -43,8 +43,7 @@ function Remove-RegistryEntries
     }
 
     $regPath = "HKEY_CLASSES_ROOT\Installer\Products"
-    Get-ChildItem -Path Registry::$regPath | Where-Object { $_.GetValue("ProductName") -match $versionFilter } | ForEach-Object
-    {
+    Get-ChildItem -Path Registry::$regPath | Where-Object { $_.GetValue("ProductName") -match $versionFilter } | ForEach-Object {
         Remove-Item Registry::$_ -Recurse -Force -Verbose
     }
 
@@ -55,10 +54,8 @@ function Remove-RegistryEntries
         "HKEY_LOCAL_MACHINE\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall"  # all users, x86
     )
 
-    $uninstallRegistrySections | Where-Object { Test-Path -Path Registry::$_ } | ForEach-Object
-    {
-        Get-ChildItem -Path Registry::$_ | Where-Object { $_.getValue("DisplayName") -match $versionFilter } | ForEach-Object
-        {
+    $uninstallRegistrySections | Where-Object { Test-Path -Path Registry::$_ } | ForEach-Object {
+        Get-ChildItem -Path Registry::$_ | Where-Object { $_.getValue("DisplayName") -match $versionFilter } | ForEach-Object {
             Remove-Item Registry::$_ -Recurse -Force -Verbose
         }
     }


### PR DESCRIPTION
1) Clean up `Uninstall` section in registry
2) Remove x86 version of tool when install x64
3) Check registry always