### PR TITLE
Revert additional builds flags to fix issue with permissions on Ubuntu

### DIFF
--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -31,16 +31,13 @@ class macOSPythonBuilder : NixPythonBuilder {
         $pythonBinariesLocation = $this.GetFullPythonToolcacheLocation()
         $configureString = "./configure --prefix=$pythonBinariesLocation --enable-optimizations --enable-shared --with-lto"
 
-        ### Supress gcc warnings
-        $env:CFLAGS="-w"
-
         ### OS X 10.11, Apple no longer provides header files for the deprecated system version of OpenSSL.
         ### Solution is to install these libraries from a third-party package manager,
         ### and then add the appropriate paths for the header and library files to configure command.
         ### Link to documentation (https://cpython-devguide.readthedocs.io/setup/#build-dependencies)
         if ($this.Version -lt "3.7.0") {
             $env:LDFLAGS="-L$(brew --prefix openssl)/lib"
-            $env:CFLAGS="-I$(brew --prefix openssl)/include $($env:CFLAGS)"
+            $env:CFLAGS="-I$(brew --prefix openssl)/include"
         } else {
             $configureString += " --with-openssl=/usr/local/opt/openssl"
         }

--- a/builders/nix-python-builder.psm1
+++ b/builders/nix-python-builder.psm1
@@ -108,13 +108,8 @@ class NixPythonBuilder : PythonBuilder {
         Write-Debug "make Python $($this.Version)-$($this.Architecture) $($this.Platform)"
         $buildOutputLocation = New-Item -Path $this.WorkFolderLocation -Name "build_output.txt" -ItemType File
         
-        # Fix error "find: build": build dir not exist before first compilation
-        New-Item -ItemType Directory -Path ./build
-
-        # execute "make" with error action = continue for python 2.* for ubuntu, because it throws errors with some modules
-        $makeErrorAction = if ($this.Version.Major -eq 2 -and $this.Platform -match "ubuntu") { "Continue" } else { "Stop" }
-        Execute-Command -Command "make 2>&1 | tee $buildOutputLocation" -ErrorAction $makeErrorAction
-        Execute-Command -Command "make install" -ErrorAction $makeErrorAction
+        Execute-Command -Command "make 2>&1 | tee $buildOutputLocation" -ErrorAction Continue	
+        Execute-Command -Command "make install" -ErrorAction Continue
 
         Write-Debug "Done; Make log location: $buildOutputLocation"
     }

--- a/builders/ubuntu-python-builder.psm1
+++ b/builders/ubuntu-python-builder.psm1
@@ -32,7 +32,6 @@ class UbuntuPythonBuilder : NixPythonBuilder {
 
         ### To build Python with SO we must pass full path to lib folder to the linker
         $env:LDFLAGS="-Wl,--rpath=${pythonBinariesLocation}/lib"
-        $env:CFLAGS="-w"
         $configureString = "./configure --prefix=$pythonBinariesLocation --enable-shared --enable-optimizations"
 
         if ($this.Version -lt "3.0.0") {


### PR DESCRIPTION
We have to revert additional build flags because they cause regression on Ubuntu permissions