### PR TITLE
Update nix-setup-template

### DIFF
--- a/installers/nix-setup-template.sh
+++ b/installers/nix-setup-template.sh
@@ -38,7 +38,7 @@ rm $PYTHON_TOOLCACHE_VERSION_ARCH_PATH/setup.sh
 
 cd $PYTHON_TOOLCACHE_VERSION_ARCH_PATH
 
-echo "Create additional symlinks (Required for the UsePythonVersion ADO task and the setup-python GitHub Action)"
+echo "Create additional symlinks (Required for the UsePythonVersion Azure Pipelines task and the setup-python GitHub Action)"
 ln -s ./bin/$PYTHON_MAJOR_DOT_MINOR python
 
 cd bin/

--- a/installers/nix-setup-template.sh
+++ b/installers/nix-setup-template.sh
@@ -38,7 +38,7 @@ rm $PYTHON_TOOLCACHE_VERSION_ARCH_PATH/setup.sh
 
 cd $PYTHON_TOOLCACHE_VERSION_ARCH_PATH
 
-echo "Create additional symlinks (Required for UsePythonVersion VSTS task)"
+echo "Create additional symlinks (Required for the UsePythonVersion ADO task and the setup-python GitHub Action)"
 ln -s ./bin/$PYTHON_MAJOR_DOT_MINOR python
 
 cd bin/


### PR DESCRIPTION
`VSTS` is long and forgotten 🙃 so it should be replaced with ADO (Azure DevOps)

Also adding a mention for GitHub Actions and the `setup-python` action