### PR TITLE
Build python with loadable sqlite extensions

### DIFF
--- a/azure-pipelines/templates/test-job.yml
+++ b/azure-pipelines/templates/test-job.yml
@@ -7,6 +7,13 @@ jobs:
   - checkout: self
     submodules: true
 
+  - task: PowerShell@2
+    displayName: 'Apply workaround for Pester tests'
+    inputs:
+      TargetType: inline
+      script: |
+        pwsh -command "& {Install-Module Pester -Force -Scope AllUsers -RequiredVersion 4.10.1}"
+
   - task: DownloadPipelineArtifact@2
     inputs:
       source: 'current'

--- a/azure-pipelines/templates/test-job.yml
+++ b/azure-pipelines/templates/test-job.yml
@@ -57,7 +57,7 @@ jobs:
     inputs:
       TargetType: inline
       script: |
-        Install-Module Pester -Force -Scope AllUsers -RequiredVersion 4.10.1
+        Install-Module Pester -Force -Scope CurrentUser -RequiredVersion 4.10.1
         Import-Module Pester
         $pesterParams = @{
           Path="./python-tests.ps1";

--- a/azure-pipelines/templates/test-job.yml
+++ b/azure-pipelines/templates/test-job.yml
@@ -7,13 +7,6 @@ jobs:
   - checkout: self
     submodules: true
 
-  - task: PowerShell@2
-    displayName: 'Apply workaround for Pester tests'
-    inputs:
-      TargetType: inline
-      script: |
-        pwsh -command "& {Install-Module Pester -Force -Scope AllUsers -RequiredVersion 4.10.1}"
-
   - task: DownloadPipelineArtifact@2
     inputs:
       source: 'current'
@@ -64,7 +57,7 @@ jobs:
     inputs:
       TargetType: inline
       script: |
-        Install-Module Pester -Force -Scope CurrentUser
+        Install-Module Pester -Force -Scope AllUsers -RequiredVersion 4.10.1
         Import-Module Pester
         $pesterParams = @{
           Path="./python-tests.ps1";

--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -45,6 +45,8 @@ class macOSPythonBuilder : NixPythonBuilder {
             $env:CFLAGS="-I$(brew --prefix openssl)/include"
         } else {
             $configureString += " --with-openssl=/usr/local/opt/openssl"
+            $env:LDFLAGS="-L$(brew --prefix sqlite3)/lib"
+            $env:CFLAGS="-I$(brew --prefix sqlite3)/include"
         }
 
         Execute-Command -Command $configureString

--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -29,7 +29,12 @@ class macOSPythonBuilder : NixPythonBuilder {
         #>
 
         $pythonBinariesLocation = $this.GetFullPythonToolcacheLocation()
-        $configureString = "./configure --prefix=$pythonBinariesLocation --enable-optimizations --enable-shared --with-lto"
+        $configureString = "./configure"
+        $configureString += " --prefix=$pythonBinariesLocation"
+        $configureString += " --enable-optimizations"
+        $configureString += " --enable-shared"
+        $configureString += " --enable-loadable-sqlite-extensions"
+        $configureString += " --with-lto"
 
         ### OS X 10.11, Apple no longer provides header files for the deprecated system version of OpenSSL.
         ### Solution is to install these libraries from a third-party package manager,

--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -41,8 +41,8 @@ class macOSPythonBuilder : NixPythonBuilder {
         ### and then add the appropriate paths for the header and library files to configure command.
         ### Link to documentation (https://cpython-devguide.readthedocs.io/setup/#build-dependencies)
         if ($this.Version -lt "3.7.0") {
-            $env:LDFLAGS="-L$(brew --prefix openssl)/lib"
-            $env:CFLAGS="-I$(brew --prefix openssl)/include"
+            $env:LDFLAGS="-L$(brew --prefix openssl)/lib -L$(brew --prefix sqlite3)/lib"
+            $env:CFLAGS="-I$(brew --prefix openssl)/include -I$(brew --prefix sqlite3)/include"
         } else {
             $configureString += " --with-openssl=/usr/local/opt/openssl"
             $env:LDFLAGS="-L$(brew --prefix sqlite3)/lib"

--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -37,8 +37,8 @@ class macOSPythonBuilder : NixPythonBuilder {
         $configureString += " --with-lto"
 
         ### Link to sqlite3 instance
-        $env:LDFLAGS="-L$(brew --prefix sqlite3)/lib"
-        $env:CFLAGS="-I$(brew --prefix sqlite3)/include"
+        $env:LDFLAGS = "-L$(brew --prefix sqlite3)/lib"
+        $env:CFLAGS = "-I$(brew --prefix sqlite3)/include"
 
         ### OS X 10.11, Apple no longer provides header files for the deprecated system version of OpenSSL.
         ### Solution is to install these libraries from a third-party package manager,

--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -36,17 +36,19 @@ class macOSPythonBuilder : NixPythonBuilder {
         $configureString += " --enable-loadable-sqlite-extensions"
         $configureString += " --with-lto"
 
+        ### Link to sqlite3 instance
+        $env:LDFLAGS="-L$(brew --prefix sqlite3)/lib"
+        $env:CFLAGS="-I$(brew --prefix sqlite3)/include"
+
         ### OS X 10.11, Apple no longer provides header files for the deprecated system version of OpenSSL.
         ### Solution is to install these libraries from a third-party package manager,
         ### and then add the appropriate paths for the header and library files to configure command.
         ### Link to documentation (https://cpython-devguide.readthedocs.io/setup/#build-dependencies)
         if ($this.Version -lt "3.7.0") {
-            $env:LDFLAGS="-L$(brew --prefix openssl)/lib -L$(brew --prefix sqlite3)/lib"
-            $env:CFLAGS="-I$(brew --prefix openssl)/include -I$(brew --prefix sqlite3)/include"
+            $env:LDFLAGS +="-L$(brew --prefix openssl)/lib"
+            $env:CFLAGS +="-I$(brew --prefix openssl)/include"
         } else {
             $configureString += " --with-openssl=/usr/local/opt/openssl"
-            $env:LDFLAGS="-L$(brew --prefix sqlite3)/lib"
-            $env:CFLAGS="-I$(brew --prefix sqlite3)/include"
         }
 
         Execute-Command -Command $configureString

--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -45,8 +45,8 @@ class macOSPythonBuilder : NixPythonBuilder {
         ### and then add the appropriate paths for the header and library files to configure command.
         ### Link to documentation (https://cpython-devguide.readthedocs.io/setup/#build-dependencies)
         if ($this.Version -lt "3.7.0") {
-            $env:LDFLAGS +="-L$(brew --prefix openssl)/lib"
-            $env:CFLAGS +="-I$(brew --prefix openssl)/include"
+            $env:LDFLAGS += " -L$(brew --prefix openssl)/lib"
+            $env:CFLAGS += " -I$(brew --prefix openssl)/include"
         } else {
             $configureString += " --with-openssl=/usr/local/opt/openssl"
         }

--- a/builders/ubuntu-python-builder.psm1
+++ b/builders/ubuntu-python-builder.psm1
@@ -36,11 +36,16 @@ class UbuntuPythonBuilder : NixPythonBuilder {
         $configureString += " --prefix=$pythonBinariesLocation"
         $configureString += " --enable-shared"
         $configureString += " --enable-optimizations"
-        $configureString += " --enable-loadable-sqlite-extensions"
 
+        ### Compile with ucs4 for Python 2.x. On 3.x, ucs4 is enabled by default
         if ($this.Version -lt "3.0.0") {
-            ### Compile with ucs4 for Python 2.x. On 3.x, ucs4 is enabled by default
             $configureString += " --enable-unicode=ucs4"
+        }
+
+        ### Compile with support of loadable sqlite extensions. Unavailable for Python 2.*
+        ### Link to documentation (https://docs.python.org/3/library/sqlite3.html#sqlite3.Connection.enable_load_extension)
+        if ($this.Version -ge "3.2.0") {
+            $configureString += " --enable-loadable-sqlite-extensions"
         }
 
         Execute-Command -Command $configureString

--- a/builders/ubuntu-python-builder.psm1
+++ b/builders/ubuntu-python-builder.psm1
@@ -32,7 +32,11 @@ class UbuntuPythonBuilder : NixPythonBuilder {
 
         ### To build Python with SO we must pass full path to lib folder to the linker
         $env:LDFLAGS="-Wl,--rpath=${pythonBinariesLocation}/lib"
-        $configureString = "./configure --prefix=$pythonBinariesLocation --enable-shared --enable-optimizations"
+        $configureString = "./configure"
+        $configureString += " --prefix=$pythonBinariesLocation"
+        $configureString += " --enable-shared"
+        $configureString += " --enable-optimizations"
+        $configureString += " --enable-loadable-sqlite-extensions"
 
         if ($this.Version -lt "3.0.0") {
             ### Compile with ucs4 for Python 2.x. On 3.x, ucs4 is enabled by default

--- a/tests/python-tests.ps1
+++ b/tests/python-tests.ps1
@@ -41,6 +41,10 @@ Describe "Tests" {
         "python ./sources/simple-test.py" | Should -ReturnZeroExitCode
     }
 
+    It "Check if sqlite3 module is installed" {
+        "python ./sources/python-sqlite3.py" | Should -ReturnZeroExitCode
+    }
+
     if (IsNixPlatform $Platform) {
 
         It "Check for failed modules in build_output" {
@@ -50,10 +54,6 @@ Describe "Tests" {
 
         It "Check if all required python modules are installed"  {
             "python ./sources/python-modules.py" | Should -ReturnZeroExitCode
-        }
-
-        It "Check if sqlite3 module is installed" {
-            "python ./sources/python-sqlite3.py" | Should -ReturnZeroExitCode
         }
 
         It "Check if python configuration is correct" {

--- a/tests/python-tests.ps1
+++ b/tests/python-tests.ps1
@@ -41,8 +41,10 @@ Describe "Tests" {
         "python ./sources/simple-test.py" | Should -ReturnZeroExitCode
     }
 
-    It "Check if sqlite3 module is installed" {
-        "python ./sources/python-sqlite3.py" | Should -ReturnZeroExitCode
+    if ($Version -ge "3.2.0") {
+        It "Check if sqlite3 module is installed" {
+            "python ./sources/python-sqlite3.py" | Should -ReturnZeroExitCode
+        }
     }
 
     if (IsNixPlatform $Platform) {

--- a/tests/python-tests.ps1
+++ b/tests/python-tests.ps1
@@ -52,6 +52,10 @@ Describe "Tests" {
             "python ./sources/python-modules.py" | Should -ReturnZeroExitCode
         }
 
+        It "Check if sqlite3 module is installed" {
+            "python ./sources/python-sqlite3.py" | Should -ReturnZeroExitCode
+        }
+
         It "Check if python configuration is correct" {
             "python ./sources/python-config-test.py" | Should -ReturnZeroExitCode
         }

--- a/tests/sources/python-sqlite3.py
+++ b/tests/sources/python-sqlite3.py
@@ -2,11 +2,11 @@ import sqlite3
 from sqlite3 import Error
 
 
-def create_connection():
+def create_connection(db_file):
     """ create a database connection to a SQLite database """
     conn = None
     try:
-        conn = sqlite3.connect()
+        conn = sqlite3.connect(db_file)
         print(sqlite3.version)
     except Error as e:
         print(e)
@@ -14,5 +14,6 @@ def create_connection():
         if conn:
             conn.close()
 
+
 if __name__ == '__main__':
-    create_connection()
+    create_connection(r"pythonsqlite.db")

--- a/tests/sources/python-sqlite3.py
+++ b/tests/sources/python-sqlite3.py
@@ -1,13 +1,13 @@
 import sqlite3
 from sqlite3 import Error
 
-
 def create_connection(db_file):
     """ create a database connection to a SQLite database """
     conn = None
     try:
-        conn = sqlite3.connect(db_file)
         print(sqlite3.version)
+        conn = sqlite3.connect(db_file)
+        conn.enable_load_extension(True)
     except Error as e:
         print(e)
         exit(1)

--- a/tests/sources/python-sqlite3.py
+++ b/tests/sources/python-sqlite3.py
@@ -10,10 +10,10 @@ def create_connection(db_file):
         print(sqlite3.version)
     except Error as e:
         print(e)
+        exit(1)
     finally:
         if conn:
             conn.close()
-
 
 if __name__ == '__main__':
     create_connection(r"pythonsqlite.db")

--- a/tests/sources/python-sqlite3.py
+++ b/tests/sources/python-sqlite3.py
@@ -5,7 +5,7 @@ def create_connection(db_file):
     """ create a database connection to a SQLite database """
     conn = None
     try:
-        print(sqlite3.version)
+        print('Sqlite3 version: ', sqlite3.version)
         conn = sqlite3.connect(db_file)
         conn.enable_load_extension(True)
     except Error as e:

--- a/tests/sources/python-sqlite3.py
+++ b/tests/sources/python-sqlite3.py
@@ -1,0 +1,18 @@
+import sqlite3
+from sqlite3 import Error
+
+
+def create_connection():
+    """ create a database connection to a SQLite database """
+    conn = None
+    try:
+        conn = sqlite3.connect()
+        print(sqlite3.version)
+    except Error as e:
+        print(e)
+    finally:
+        if conn:
+            conn.close()
+
+if __name__ == '__main__':
+    create_connection()


### PR DESCRIPTION
This PR build python for nix systems with enabled loadable sqlite extensions. It also adds built-in test for sqlite3 module.

**How it was tested:**
[2.7.17](https://msmobilecenter.visualstudio.com/Mobile-Center/_build/results?buildId=914425&view=results)
[3.5.9](https://msmobilecenter.visualstudio.com/Mobile-Center/_build/results?buildId=914424&view=results)
[3.6.10](https://msmobilecenter.visualstudio.com/Mobile-Center/_build/results?buildId=914423&view=results)
[3.7.7](https://msmobilecenter.visualstudio.com/Mobile-Center/_build/results?buildId=914422&view=results)
[3.8.3](https://msmobilecenter.visualstudio.com/Mobile-Center/_build/results?buildId=914414&view=results)