### PR TITLE
Build Python3 for nix and darwin with enabled loadable sqlite extensions

### DIFF
--- a/azure-pipelines/templates/test-job.yml
+++ b/azure-pipelines/templates/test-job.yml
@@ -57,7 +57,7 @@ jobs:
     inputs:
       TargetType: inline
       script: |
-        Install-Module Pester -Force -Scope CurrentUser
+        Install-Module Pester -Force -Scope CurrentUser -RequiredVersion 4.10.1
         Import-Module Pester
         $pesterParams = @{
           Path="./python-tests.ps1";

--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -29,17 +29,29 @@ class macOSPythonBuilder : NixPythonBuilder {
         #>
 
         $pythonBinariesLocation = $this.GetFullPythonToolcacheLocation()
-        $configureString = "./configure --prefix=$pythonBinariesLocation --enable-optimizations --enable-shared --with-lto"
+        $configureString = "./configure"
+        $configureString += " --prefix=$pythonBinariesLocation"
+        $configureString += " --enable-optimizations"
+        $configureString += " --enable-shared"
+        $configureString += " --with-lto"
 
         ### OS X 10.11, Apple no longer provides header files for the deprecated system version of OpenSSL.
         ### Solution is to install these libraries from a third-party package manager,
         ### and then add the appropriate paths for the header and library files to configure command.
         ### Link to documentation (https://cpython-devguide.readthedocs.io/setup/#build-dependencies)
         if ($this.Version -lt "3.7.0") {
-            $env:LDFLAGS="-L$(brew --prefix openssl)/lib"
-            $env:CFLAGS="-I$(brew --prefix openssl)/include"
+            $env:LDFLAGS = "-L$(brew --prefix openssl)/lib"
+            $env:CFLAGS = "-I$(brew --prefix openssl)/include"
         } else {
             $configureString += " --with-openssl=/usr/local/opt/openssl"
+        }
+
+        ### Compile with support of loadable sqlite extensions. Unavailable for Python 2.*
+        ### Link to documentation (https://docs.python.org/3/library/sqlite3.html#sqlite3.Connection.enable_load_extension)
+        if ($this.Version -ge "3.2.0") {
+            $configureString += " --enable-loadable-sqlite-extensions"
+            $env:LDFLAGS += " -L$(brew --prefix sqlite3)/lib"
+            $env:CFLAGS += " -I$(brew --prefix sqlite3)/include"
         }
 
         Execute-Command -Command $configureString

--- a/builders/ubuntu-python-builder.psm1
+++ b/builders/ubuntu-python-builder.psm1
@@ -32,11 +32,20 @@ class UbuntuPythonBuilder : NixPythonBuilder {
 
         ### To build Python with SO we must pass full path to lib folder to the linker
         $env:LDFLAGS="-Wl,--rpath=${pythonBinariesLocation}/lib"
-        $configureString = "./configure --prefix=$pythonBinariesLocation --enable-shared --enable-optimizations"
+        $configureString = "./configure"
+        $configureString += " --prefix=$pythonBinariesLocation"
+        $configureString += " --enable-shared"
+        $configureString += " --enable-optimizations"
 
+        ### Compile with ucs4 for Python 2.x. On 3.x, ucs4 is enabled by default
         if ($this.Version -lt "3.0.0") {
-            ### Compile with ucs4 for Python 2.x. On 3.x, ucs4 is enabled by default
             $configureString += " --enable-unicode=ucs4"
+        }
+
+        ### Compile with support of loadable sqlite extensions. Unavailable for Python 2.*
+        ### Link to documentation (https://docs.python.org/3/library/sqlite3.html#sqlite3.Connection.enable_load_extension)
+        if ($this.Version -ge "3.2.0") {
+            $configureString += " --enable-loadable-sqlite-extensions"
         }
 
         Execute-Command -Command $configureString

--- a/tests/python-tests.ps1
+++ b/tests/python-tests.ps1
@@ -41,6 +41,12 @@ Describe "Tests" {
         "python ./sources/simple-test.py" | Should -ReturnZeroExitCode
     }
 
+    if ($Version -ge "3.2.0") {
+        It "Check if sqlite3 module is installed" {
+            "python ./sources/python-sqlite3.py" | Should -ReturnZeroExitCode
+        }
+    }
+
     if (IsNixPlatform $Platform) {
 
         It "Check for failed modules in build_output" {

--- a/tests/sources/python-sqlite3.py
+++ b/tests/sources/python-sqlite3.py
@@ -1,0 +1,19 @@
+import sqlite3
+from sqlite3 import Error
+
+def create_connection(db_file):
+    """ create a database connection to a SQLite database """
+    conn = None
+    try:
+        print('Sqlite3 version: ', sqlite3.version)
+        conn = sqlite3.connect(db_file)
+        conn.enable_load_extension(True)
+    except Error as e:
+        print(e)
+        exit(1)
+    finally:
+        if conn:
+            conn.close()
+
+if __name__ == '__main__':
+    create_connection(r"pythonsqlite.db")


### PR DESCRIPTION
**Description:**
This PR build Python3 for nix and darwin systems with enabled loadable sqlite extensions. It also adds built-in test for sqlite3 module.

**Related Issue:** https://github.com/actions/virtual-environments/issues/317

**How it was tested:**
- [3.8.3](https://msmobilecenter.visualstudio.com/Mobile-Center/_build/results?buildId=915461&view=results)
- [3.7.7](https://msmobilecenter.visualstudio.com/Mobile-Center/_build/results?buildId=915462&view=results)
- [3.6.10](https://msmobilecenter.visualstudio.com/Mobile-Center/_build/results?buildId=915463&view=results)
- [3.5.9](https://msmobilecenter.visualstudio.com/Mobile-Center/_build/results?buildId=915465&view=results)