### PR TITLE
Fix python tests

### DIFF
--- a/azure-pipelines/templates/test-job.yml
+++ b/azure-pipelines/templates/test-job.yml
@@ -76,6 +76,7 @@ jobs:
           }
         }
         Invoke-Pester -Script $pesterParams -OutputFile "test_results.xml" -OutputFormat NUnitXml
+      pwsh: true
       workingDirectory: '$(Build.SourcesDirectory)/tests'
 
   - task: PublishTestResults@2

--- a/tests/python-tests.ps1
+++ b/tests/python-tests.ps1
@@ -1,5 +1,5 @@
 param (
-    [string] [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()]
+    [semver] [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()]
     $Version,
     [string] [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()]
     $Platform


### PR DESCRIPTION
We changed version type from `string` to `semver` in the `python-tests.ps1` script