### PR TITLE
Adding Python manifest lib path to LD_LIBRARY_PATH before installing pip

### DIFF
--- a/installers/nix-setup-template.sh
+++ b/installers/nix-setup-template.sh
@@ -31,7 +31,7 @@ fi
 echo "Create Python $PYTHON_FULL_VERSION folder"
 mkdir -p $PYTHON_TOOLCACHE_VERSION_ARCH_PATH
 
-echo "Copy Python binaries to hostedtoolcache folder"
+echo "Copy Python binaries to $PYTHON_TOOLCACHE_VERSION_ARCH_PATH"
 cp -R ./* $PYTHON_TOOLCACHE_VERSION_ARCH_PATH
 rm $PYTHON_TOOLCACHE_VERSION_ARCH_PATH/setup.sh
 

--- a/installers/nix-setup-template.sh
+++ b/installers/nix-setup-template.sh
@@ -49,6 +49,7 @@ fi
 chmod +x ../python $PYTHON_MAJOR $PYTHON_MAJOR_DOT_MINOR $PYTHON_MAJORMINOR python
 
 echo "Upgrading PIP..."
+export LD_LIBRARY_PATH="$PYTHON_TOOLCACHE_VERSION_ARCH_PATH/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 ./python -m ensurepip
 ./python -m pip install --ignore-installed pip
 


### PR DESCRIPTION
Hello 👋 

Related to https://github.com/actions/setup-python/issues/131 - this change to the nix installer should help with the setup/install of `pip` for a new manifest by appending another library path.

With this in place, the shared libraries will be found upon install of the manifest by the `actions/setup-python` action.

The _only_ downside here, would need to re-bake every manifest archive.