### PR TITLE
Move release and PR creation to GitHub Actions

### DIFF
--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -1,0 +1,33 @@
+name: Create Pull Request
+on:
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  create_pr:
+    name: Create Pull Request
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Create versions-manifest.json
+      run: |
+        ./helpers/packages-generation/manifest-generator.ps1 -RepositoryFullName "$env:GITHUB_REPOSITORY" `
+                                                             -GitHubAccessToken "${{secrets.GITHUB_TOKEN}}" `
+                                                             -OutputFile "./versions-manifest.json" `
+                                                             -ConfigurationFile "./config/python-manifest-config.json"
+    - name: Create GitHub PR
+      run: |
+        $formattedDate = Get-Date -Format "MM/dd/yyyy"
+        ./helpers/github/create-pull-request.ps1 `
+                            -RepositoryFullName "$env:GITHUB_REPOSITORY" `
+                            -AccessToken "${{secrets.GITHUB_TOKEN}}" `
+                            -BranchName "update-versions-manifest-file" `
+                            -CommitMessage "Update versions-manifest" `
+                            -PullRequestTitle "[versions-manifest] Update for release from ${formattedDate}" `
+                            -PullRequestBody "Update versions-manifest.json for release from ${formattedDate}"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,18 @@
+name: Create release
+on:
+  repository_dispatch:
+    types: [create-release]
+
+jobs:
+  create_release:
+    name: Create release ${{ github.event.client_payload.ToolVersion }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Create release for Python ${{ github.event.client_payload.ToolVersion }}
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.event.client_payload.TagName }}
+        release_name: ${{ github.event.client_payload.ToolVersion }}
+        body: ${{ github.event.client_payload.ReleaseBody }}

--- a/azure-pipelines/build-python-packages.yml
+++ b/azure-pipelines/build-python-packages.yml
@@ -116,3 +116,17 @@ stages:
     Architecture: x86
   jobs:
   - template: /azure-pipelines/templates/test-job.yml
+
+- stage: Publish_Release
+  dependsOn: [Test_Python_MacOS, Test_Python_Ubuntu_1604, Test_Python_Ubuntu_1804, Test_Python_Ubuntu_2004, Test_Python_x64_Windows, Test_Python_x86_Windows]
+  jobs:
+  - deployment: Publish_Release
+    pool:
+      name: Azure Pipelines
+      vmImage: ubuntu-18.04
+    environment: 'Get Available Tools Versions - Publishing Approval'
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+          - template: /azure-pipelines/templates/publish-release-steps.yml

--- a/azure-pipelines/templates/publish-release-steps.yml
+++ b/azure-pipelines/templates/publish-release-steps.yml
@@ -43,4 +43,5 @@ steps:
       Import-Module (Join-Path (Get-Location).Path "github-api.psm1")
       $gitHubApi = Get-GitHubApi -RepositoryFullName "$(Build.Repository.Name)" -AccessToken "$(GITHUB_TOKEN)"
       $gitHubApi.CreateWorkflowDispatch("$(WORKFLOW_FILE_NAME)", "$(WORKFLOW_DISPATCH_REF)", "$(INPUTS)")
+      Write-Host "Please find created Pull request here: $(Build.Repository.Uri)/pulls"
     workingDirectory: '$(Build.SourcesDirectory)/helpers/github'

--- a/azure-pipelines/templates/publish-release-steps.yml
+++ b/azure-pipelines/templates/publish-release-steps.yml
@@ -1,0 +1,46 @@
+steps:
+- download: none
+
+- checkout: self
+  submodules: true
+
+- task: DownloadPipelineArtifact@2
+  inputs:
+    source: 'current'
+    path: $(Build.BinariesDirectory)
+
+- task: PowerShell@2
+  displayName: 'Create release Python $(VERSION)'
+  inputs:
+    TargetType: inline
+    script: |
+      $tagName = "$(VERSION)-$(Build.BuildId)"
+      $releaseBody = "Python $(VERSION)"
+      ./helpers/github/create-release.ps1 -RepositoryFullName "$(Build.Repository.Name)" `
+                                          -AccessToken "$(GITHUB_TOKEN)" `
+                                          -ToolVersion "$(VERSION)" `
+                                          -TagName "$tagName" `
+                                          -ReleaseBody "$releaseBody" `
+                                          -EventType "$(EVENT_TYPE)"
+- task: GitHubRelease@1
+  displayName: 'Upload release assets'
+  inputs:
+    gitHubConnection: 'Github Connection'
+    action: edit
+    tag: '$(VERSION)-$(Build.BuildId)'
+    title: '$(VERSION)'
+    releaseNotesSource: inline
+    releaseNotesInline: '$(RELEASE_NOTES_CONTENT)'
+    assets: '$(Build.BinariesDirectory)/*/*'
+    assetUploadMode: replace
+    addChangeLog: false
+
+- task: PowerShell@2
+  displayName: 'Trigger "Create Pull Request" workflow'
+  inputs:
+    TargetType: inline
+    script: |
+      Import-Module (Join-Path (Get-Location).Path "github-api.psm1")
+      $gitHubApi = Get-GitHubApi -RepositoryFullName "$(Build.Repository.Name)" -AccessToken "$(GITHUB_TOKEN)"
+      $gitHubApi.CreateWorkflowDispatch("$(WORKFLOW_FILE_NAME)", "$(WORKFLOW_DISPATCH_REF)", "$(INPUTS)")
+    workingDirectory: '$(Build.SourcesDirectory)/helpers/github'


### PR DESCRIPTION
In scope of this PR we've moved release and PR creation from AzureDevOps to GitHub Actions.

**Details:**
The main goal of these changes is to switch the repository to use the system account to publish Python releases and create PRs with updating the `versions-manifest.json` file. For this purpose we use `GITHUB_TOKEN` which is automatically generated by GitHub. Unfortunately, we were not able to get rid of the personal access token completely. We have to authenticate using a personal access token to trigger workflow configured with the `workflow_dispatch` and `repository_dispatch` events.

We cannot completely move python-versions CI to the GitHub Actions because we have to use `macOS-10.14` pool to build our packages. We will move to GitHub Actions as soon as possible.