### PR TITLE
Validate that 3.9.0-beta.4 is not working

### DIFF
--- a/.github/workflows/releases-validation.yml
+++ b/.github/workflows/releases-validation.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
-        python: [3.5.4, 3.6.7, 3.7.5, 3.8.1]
+        python: [3.5.4, 3.6.7, 3.7.5, 3.8.1, 3.9.0-beta.4]
     steps:
     - name: setup-python ${{ matrix.python }}
       uses: actions/setup-python@v2


### PR DESCRIPTION
The latest version of Python on https://github.com/actions/python-versions/blob/main/versions-manifest.json is 3.9.0-beta.4 but it ___does not work___.  actions/virtual-environments#1518 is a related request to add Python 3.9.0 release candidate 1.