### PR TITLE
Exclude symbol module from python 3.10 and higher.

### DIFF
--- a/tests/python-tests.ps1
+++ b/tests/python-tests.ps1
@@ -7,6 +7,7 @@ param (
 
 Import-Module (Join-Path $PSScriptRoot "../helpers/pester-extensions.psm1")
 Import-Module (Join-Path $PSScriptRoot "../helpers/common-helpers.psm1")
+Import-Module (Join-Path $PSScriptRoot "../builders/python-version.psm1")
 
 function Analyze-MissingModules([string] $buildOutputLocation) {
     $searchStringStart = "Failed to build these modules:"
@@ -59,7 +60,8 @@ Describe "Tests" {
         }
 
         It "Check if python configuration is correct" {
-            "python ./sources/python-config-test.py $Version" | Should -ReturnZeroExitCode
+            $nativeVersion = Convert-Version -version $Version
+            "python ./sources/python-config-test.py $Version $nativeVersion" | Should -ReturnZeroExitCode
         }
 
         It "Check if shared libraries are linked correctly" {

--- a/tests/sources/python-config-test.py
+++ b/tests/sources/python-config-test.py
@@ -1,4 +1,5 @@
 import distutils.sysconfig
+from distutils.version import StrictVersion
 import sysconfig
 import sys
 import platform
@@ -7,6 +8,7 @@ import os
 # Define variables
 os_type = platform.system()
 version = sys.argv[1]
+nativeVersion = sys.argv[2]
 
 lib_dir_path = sysconfig.get_config_var('LIBDIR')
 ld_library_name = sysconfig.get_config_var('LDLIBRARY')
@@ -41,7 +43,7 @@ else:
 ### Validate macOS
 if os_type == 'Darwin':
     ### Validate openssl links
-    if version < "3.7.0":
+    if StrictVersion(nativeVersion) < StrictVersion("3.7.0"):
         expected_ldflags = '-L/usr/local/opt/openssl@1.1/lib'
         ldflags = sysconfig.get_config_var('LDFLAGS')
 

--- a/tests/sources/python-modules.py
+++ b/tests/sources/python-modules.py
@@ -255,6 +255,10 @@ if sys.version_info > (3, 7):
 if sys.version_info > (3, 8):
     standard_library.remove('dummy_threading')
 
+# 'symbol' module has been removed from Python 3.10
+if sys.version_info >= (3, 10):
+    standard_library.remove('symbol')
+
 # Remove tkinter and Easter eggs
 excluded_modules = [
     'antigravity',


### PR DESCRIPTION
- Exclude symbol module for versions higher then 3.10.