### PR TITLE
Skip pyinstaller for python 2

### DIFF
--- a/tests/python-tests.ps1
+++ b/tests/python-tests.ps1
@@ -75,7 +75,7 @@ Describe "Tests" {
     }
 
     # Pyinstaller 3.5 does not support Python 3.8.0. Check issue https://github.com/pyinstaller/pyinstaller/issues/4311
-    if ($Version -lt "3.8.0") {
+    if ($Version -lt "3.8.0" -and $Version.Major -ne "2") {
         It "Validate Pyinstaller" {
             "pip install pyinstaller" | Should -ReturnZeroExitCode
             "pyinstaller --onefile ./sources/simple-test.py" | Should -ReturnZeroExitCode


### PR DESCRIPTION
 - skip test for python 2 (because python 2 is deprecated).