### PR TITLE
Fix PowerShell issue with relative paths

### DIFF
--- a/azure-pipelines/templates/build-job.yml
+++ b/azure-pipelines/templates/build-job.yml
@@ -7,7 +7,17 @@ jobs:
   steps:
   - checkout: self
     submodules: true
-    
+
+# We need this temporary step to have a consistent version of PowerShell on all images.
+  - task: PowerShell@2
+    displayName: 'Update PowerShell version for macOS'
+    condition: eq(variables['Platform'], 'darwin')
+    inputs:
+      TargetType: inline
+      script: |
+        brew update
+        brew cask upgrade powershell
+
   - task: PowerShell@2
     displayName: 'Build Python $(VERSION)'
     inputs:

--- a/azure-pipelines/templates/test-job.yml
+++ b/azure-pipelines/templates/test-job.yml
@@ -27,6 +27,7 @@ jobs:
       archiveFilePatterns: '$(Build.BinariesDirectory)/python-$(VERSION)-$(Platform)-$(Architecture).*'
       destinationFolder: $(Build.BinariesDirectory)
       cleanDestinationFolder: false
+      overwriteExistingFiles: true
 
   - task: PowerShell@2
     displayName: 'Apply build artifact to the local machines'

--- a/builders/build-python.ps1
+++ b/builders/build-python.ps1
@@ -1,6 +1,6 @@
-using module "./builders/win-python-builder.psm1"
-using module "./builders/ubuntu-python-builder.psm1"
-using module "./builders/macos-python-builder.psm1"
+using module "./win-python-builder.psm1"
+using module "./ubuntu-python-builder.psm1"
+using module "./macos-python-builder.psm1"
 
 <#
 .SYNOPSIS

--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -1,4 +1,4 @@
-using module "./builders/nix-python-builder.psm1"
+using module "./nix-python-builder.psm1"
 
 class macOSPythonBuilder : NixPythonBuilder {
     <#

--- a/builders/nix-python-builder.psm1
+++ b/builders/nix-python-builder.psm1
@@ -1,4 +1,4 @@
-using module "./builders/python-builder.psm1"
+using module "./python-builder.psm1"
 
 class NixPythonBuilder : PythonBuilder {
     <#

--- a/builders/ubuntu-python-builder.psm1
+++ b/builders/ubuntu-python-builder.psm1
@@ -1,4 +1,4 @@
-using module "./builders/nix-python-builder.psm1"
+using module "./nix-python-builder.psm1"
 
 class UbuntuPythonBuilder : NixPythonBuilder {
     <#

--- a/builders/win-python-builder.psm1
+++ b/builders/win-python-builder.psm1
@@ -1,4 +1,4 @@
-using module "./builders/python-builder.psm1"
+using module "./python-builder.psm1"
 
 class WinPythonBuilder : PythonBuilder {
     <#


### PR DESCRIPTION
PowerShell 7.1.0 introduces breaking changes that affect relative paths. Python packages generation fails with the following error:
```
The specified module '/home/vsts/work/1/s/builders/builders/win-python-builder.psm1' was not loaded because no valid module file was found in any module directory.
```

In scope of this PR we prepared fix for this issue. Also we added temporary step to update PowerShell version on macOS Mojave.

[Link to the build](https://github.visualstudio.com/virtual-environments/_build/results?buildId=89671&view=results)

Related issue: [#1473](https://github.com/actions/virtual-environments-internal/issues/1473)