### PR TITLE
Replace StrictVersion to LooseVersion

### DIFF
--- a/tests/sources/python-config-test.py
+++ b/tests/sources/python-config-test.py
@@ -1,5 +1,5 @@
 import distutils.sysconfig
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 import sysconfig
 import sys
 import platform
@@ -43,7 +43,7 @@ else:
 ### Validate macOS
 if os_type == 'Darwin':
     ### Validate openssl links
-    if StrictVersion(nativeVersion) < StrictVersion("3.7.0"):
+    if LooseVersion(nativeVersion) < LooseVersion("3.7.0"):
         expected_ldflags = '-L/usr/local/opt/openssl@1.1/lib'
         ldflags = sysconfig.get_config_var('LDFLAGS')
 


### PR DESCRIPTION
According to this [documentation](https://docs.openstack.org/tooz/stein/_modules/distutils/version.html) it's better to change StrictVersion to LooseVersion, because:
 - LooseVersion will be able to resolve for example 3.9.0rc1.
 - It has the same comparison as for beta, alpha and other versions.