### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @actions-service


### PR DESCRIPTION
Adding `CODEOWNERS` for this repo.  We're doing this to track ownership of all repos in the `actions` org.

For info on how `CODEOWNERS` works, see the [blog post](https://github.blog/2017-07-06-introducing-code-owners/).

@maxim-lobanov once you've got a team set up in `actions` you want to use, you can add it here as well.