### PR TITLE
Update the list of modules in tests for Python 3.10

### DIFF
--- a/tests/sources/python-modules.py
+++ b/tests/sources/python-modules.py
@@ -256,9 +256,10 @@ if sys.version_info > (3, 7):
 if sys.version_info > (3, 8):
     standard_library.remove('dummy_threading')
 
-# 'symbol' module has been removed from Python 3.10
+# 'symbol' and 'formatter' modules have been removed from Python 3.10
 if sys.version_info >= (3, 10):
     standard_library.remove('symbol')
+    standard_library.remove('formatter')
 
 # Remove tkinter and Easter eggs
 excluded_modules = [
@@ -270,7 +271,6 @@ excluded_modules = [
 def check_missing_modules(expected_modules):
     missing = []
     for module in expected_modules:
-        print('Try to import module ', module)
         try:
             importlib.import_module(module)
         except:


### PR DESCRIPTION
The `formatter` module has been removed from Python 3.10 (link to the [Python 3.10 documentation](https://docs.python.org/3.10/whatsnew/3.10.html#removed)). In scope of this PR we fixed our tests according to Python 3.10 update.

[Link to the build](https://github.visualstudio.com/virtual-environments/_build/results?buildId=91810&view=results)