### PR TITLE
Add a new workflow to test Python versions

### DIFF
--- a/.github/workflows/test-python-version.yml
+++ b/.github/workflows/test-python-version.yml
@@ -1,0 +1,34 @@
+name: Test Python version
+on: 
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Python version to build'
+        required: true
+      architecture:
+        description: 'The target architecture (x86, x64) of the Python'
+        required: false
+        default: 'x64'
+
+jobs:
+  test-python:
+    name: Test Python ${{ github.event.inputs.version }} ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-18.04, ubuntu-20.04] 
+    steps:
+    - name: Setup Python ${{ github.event.inputs.version }}
+      uses: actions/setup-python@main
+      with:
+        python-version: ${{ github.event.inputs.version }}
+        architecture: ${{ github.event.inputs.architecture }}
+
+    - name: Validate version
+      run: |
+        python --version
+      shell: pwsh
+
+    - name: Run simple code
+      run: python -c 'import math; print(math.factorial(5))'


### PR DESCRIPTION
We added the `test-python-version.yml ` workflow to be able to validate new versions of Python using the `actions/setup-python` action. This workflow was configured with the `workflow_dispatch` event, so we can manually trigger a workflow run and specify any Python version available in the [versions-manifest.json](https://github.com/actions/python-versions/blob/main/versions-manifest.json):
![image](https://user-images.githubusercontent.com/46996400/102230616-2b0fc080-3efe-11eb-8cac-eae31eb847cb.png)

