### PR TITLE
Remove the temporary step with PowerShell version upgrade

### DIFF
--- a/azure-pipelines/templates/build-job.yml
+++ b/azure-pipelines/templates/build-job.yml
@@ -8,16 +8,6 @@ jobs:
   - checkout: self
     submodules: true
 
-# We need this temporary step to have a consistent version of PowerShell on all images.
-  - task: PowerShell@2
-    displayName: 'Update PowerShell version for macOS'
-    condition: eq(variables['Platform'], 'darwin')
-    inputs:
-      TargetType: inline
-      script: |
-        brew update
-        brew upgrade --cask powershell
-
   - task: PowerShell@2
     displayName: 'Build Python $(VERSION)'
     inputs:

--- a/azure-pipelines/templates/build-job.yml
+++ b/azure-pipelines/templates/build-job.yml
@@ -16,7 +16,7 @@ jobs:
       TargetType: inline
       script: |
         brew update
-        brew cask upgrade powershell
+        brew upgrade --cask powershell
 
   - task: PowerShell@2
     displayName: 'Build Python $(VERSION)'


### PR DESCRIPTION
PowerShell version is consistent on all images, so we no longer need the temporary step to update it.

[Related build](https://github.visualstudio.com/virtual-environments/_build/results?buildId=93274&view=results)