### PR TITLE
Add flag to skip warnings location of pip

### DIFF
--- a/installers/nix-setup-template.sh
+++ b/installers/nix-setup-template.sh
@@ -50,7 +50,7 @@ chmod +x ../python $PYTHON_MAJOR $PYTHON_MAJOR_DOT_MINOR $PYTHON_MAJORMINOR pyth
 
 echo "Upgrading PIP..."
 ./python -m ensurepip
-./python -m pip install --ignore-installed pip
+./python -m pip install --ignore-installed pip --no-warn-script-location
 
 echo "Create complete file"
 touch $PYTHON_TOOLCACHE_VERSION_PATH/x64.complete

--- a/installers/win-setup-template.ps1
+++ b/installers/win-setup-template.ps1
@@ -123,7 +123,7 @@ if ($LASTEXITCODE -ne 0) {
 
 Write-Host "Install and upgrade Pip"
 $PythonExePath = Join-Path -Path $PythonArchPath -ChildPath "python.exe"
-cmd.exe /c "$PythonExePath -m ensurepip && $PythonExePath -m pip install --upgrade pip"
+cmd.exe /c "$PythonExePath -m ensurepip && $PythonExePath -m pip install --upgrade pip --no-warn-script-location"
 
 Write-Host "Create complete file"
 New-Item -ItemType File -Path $PythonVersionPath -Name "$Architecture.complete" | Out-Null


### PR DESCRIPTION
In scope of this pull request we add extra flag during updating pip. It should skip warnings that pip is not added to the path. It will suppress warnings in setup-python during installation on the flight.
issue: https://github.com/actions/setup-python/issues/146