### PR TITLE
Add symlink `python3`

### DIFF
--- a/installers/win-setup-template.ps1
+++ b/installers/win-setup-template.ps1
@@ -121,6 +121,11 @@ if ($LASTEXITCODE -ne 0) {
     Throw "Error happened during Python installation"
 }
 
+Write-Host "Create `python3` symlink"
+if ($MajorVersion -ne "2") {
+    New-Item -Path "$PythonArchPath\python3.exe" -ItemType SymbolicLink -Value "$PythonArchPath\python.exe"
+}
+
 Write-Host "Install and upgrade Pip"
 $PythonExePath = Join-Path -Path $PythonArchPath -ChildPath "python.exe"
 cmd.exe /c "$PythonExePath -m ensurepip && $PythonExePath -m pip install --upgrade pip --no-warn-script-location"

--- a/versions-manifest.json
+++ b/versions-manifest.json
@@ -876,7 +876,7 @@
   {
     "version": "3.7.9",
     "stable": true,
-    "release_url": "https://github.com/actions/python-versions/releases/tag/3.7.9-86953",
+    "release_url": "https://github.com/vsafonkin/python-versions/releases/tag/3.7.9-1341055",
     "files": [
       {
         "filename": "python-3.7.9-darwin-x64.tar.gz",
@@ -909,13 +909,13 @@
         "filename": "python-3.7.9-win32-x64.zip",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/python-versions/releases/download/3.7.9-86953/python-3.7.9-win32-x64.zip"
+        "download_url": "https://github.com/vsafonkin/python-versions/releases/download/3.7.9-1341055/python-3.7.9-win32-x64.zip"
       },
       {
         "filename": "python-3.7.9-win32-x86.zip",
         "arch": "x86",
         "platform": "win32",
-        "download_url": "https://github.com/actions/python-versions/releases/download/3.7.9-86953/python-3.7.9-win32-x86.zip"
+        "download_url": "https://github.com/vsafonkin/python-versions/releases/download/3.7.9-1341055/python-3.7.9-win32-x86.zip"
       }
     ]
   },

--- a/versions-manifest.json
+++ b/versions-manifest.json
@@ -876,7 +876,7 @@
   {
     "version": "3.7.9",
     "stable": true,
-    "release_url": "https://github.com/vsafonkin/python-versions/releases/tag/3.7.9-1341055",
+    "release_url": "https://github.com/actions/python-versions/releases/tag/3.7.9-86953",
     "files": [
       {
         "filename": "python-3.7.9-darwin-x64.tar.gz",
@@ -909,13 +909,13 @@
         "filename": "python-3.7.9-win32-x64.zip",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/vsafonkin/python-versions/releases/download/3.7.9-1341055/python-3.7.9-win32-x64.zip"
+        "download_url": "https://github.com/actions/python-versions/releases/download/3.7.9-86953/python-3.7.9-win32-x64.zip"
       },
       {
         "filename": "python-3.7.9-win32-x86.zip",
         "arch": "x86",
         "platform": "win32",
-        "download_url": "https://github.com/vsafonkin/python-versions/releases/download/3.7.9-1341055/python-3.7.9-win32-x86.zip"
+        "download_url": "https://github.com/actions/python-versions/releases/download/3.7.9-86953/python-3.7.9-win32-x86.zip"
       }
     ]
   },


### PR DESCRIPTION
Added creation of symlink `python3` in setup script for Windows.

Test build image with these changed packages: https://github.visualstudio.com/virtual-environments/_build/results?buildId=96226&view=results

Deployed VM:
![Screenshot 2021-01-22 at 10 58 18 AM](https://user-images.githubusercontent.com/7628945/105463999-ec5dea80-5ca1-11eb-8884-3bf16bc80625.png)

Issue: [#2461](https://github.com/actions/virtual-environments/issues/2461)