### PR TITLE
Ignore tkinter module for alpha & beta versions of Pyrhon 3.10.0

### DIFF
--- a/tests/python-tests.ps1
+++ b/tests/python-tests.ps1
@@ -24,7 +24,7 @@ function Analyze-MissingModules([string] $buildOutputLocation) {
         $module = $regexMatch.Groups[1].Value.Trim()
         Write-Host "Failed missing modules:"
         Write-Host $module
-        if ( ($module -eq "_tkinter") -and ($Version -eq "3.10.0-alpha.6") ) {
+        if ( ($module -eq "_tkinter") -and ( $Version.StartsWith("3.10.0") -and ( ($Version -like "*beta*") -or ($Version -like "*alpha*") ) ) ) {
           Write-Host "$module $Version ignored"
         } else {
           return 1

--- a/tests/python-tests.ps1
+++ b/tests/python-tests.ps1
@@ -24,7 +24,7 @@ function Analyze-MissingModules([string] $buildOutputLocation) {
         $module = $regexMatch.Groups[1].Value.Trim()
         Write-Host "Failed missing modules:"
         Write-Host $module
-        if ( ($module -eq "_tkinter") -and ( $Version.StartsWith("3.10.0") -and ( ($Version -like "*beta*") -or ($Version -like "*alpha*") ) ) ) {
+        if ( ($module -eq "_tkinter") -and ( ($Version -like "3.10.0-beta*") -or ($Version -like "3.10.0-alpha*") ) ) {
           Write-Host "$module $Version ignored"
         } else {
           return 1


### PR DESCRIPTION
The [issue](https://github.com/actions/virtual-environments-internal/issues/1886) with the `_tkinter` still exists in the Python 3.10.0-alpha.7 on macOS. In scope of this PR we updated a condition to skip tkinter validation for alpha & beta Python versions.

[Successful build](https://github.visualstudio.com/virtual-environments/_build/results?buildId=104136&view=results)