### PR TITLE
Include debug on Windows

### DIFF
--- a/installers/win-setup-template.ps1
+++ b/installers/win-setup-template.ps1
@@ -67,7 +67,7 @@ function Get-ExecParams {
     if ($IsMSI) {
         "TARGETDIR=$PythonArchPath ALLUSERS=1"
     } else {
-        "DefaultAllUsersTargetDir=$PythonArchPath InstallAllUsers=1"
+        "DefaultAllUsersTargetDir=$PythonArchPath InstallAllUsers=1 Include_debug=1"
     }
 }
 


### PR DESCRIPTION
This adds the installer option to include the debug binaries (i.e. `python_d.exe`) on Windows.

Fixes https://github.com/actions/setup-python/issues/86