### PR TITLE
Move manifest validation pipeline from Azure DevOps

### DIFF
--- a/.github/workflows/validate-manifest.yml
+++ b/.github/workflows/validate-manifest.yml
@@ -31,7 +31,7 @@ jobs:
     name: Check validation for failures 
     runs-on: ubuntu-latest
     needs: [validation]
-    if: failure()
+    if: success()
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/validate-manifest.yml
+++ b/.github/workflows/validate-manifest.yml
@@ -1,8 +1,6 @@
 name: Validate manifest
 
 on:
-   workflow_dispatch:
-   
    schedule:
     - cron:  '0 8,20 * * *'
     

--- a/.github/workflows/validate-manifest.yml
+++ b/.github/workflows/validate-manifest.yml
@@ -5,8 +5,10 @@ on:
     - cron:  '0 8,20 * * *'
     
    pull_request:
-    branches:
+     branches:
       - main
+     paths:
+      - 'versions-manifest.json'
 env:
   TOOL_NAME: "Python"
 defaults:

--- a/.github/workflows/validate-manifest.yml
+++ b/.github/workflows/validate-manifest.yml
@@ -1,0 +1,47 @@
+name: Validate manifest
+
+on:
+   workflow_dispatch:
+   
+   schedule:
+    - cron:  '0 8,20 * * *'
+    
+   pull_request:
+    branches:
+      - main
+env:
+  TOOL_NAME: "Python"
+defaults:
+  run:
+    shell: pwsh
+    
+jobs:
+  validation:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v2
+      with:
+          submodules: true
+          
+    - name: Validate python-versions manifest
+      run: .\helpers\packages-generation\manifest-validator.ps1 -ManifestUrl https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
+
+  check_build:
+    name: Check validation for failures 
+    runs-on: ubuntu-latest
+    needs: [validation]
+    if: failure()
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Send Slack notification if validation fails
+        run: |
+          $pipelineUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
+          $message = "The validation of python-versions manifest failed. \nLink to the pipeline: $pipelineUrl"
+          .\helpers\get-new-tool-versions\send-slack-notification.ps1 -Url "${{ secrets.SLACK_CHANNEL_URL }}" `
+                                                                      -ToolName "${{ env.TOOL_NAME }}" `
+                                                                      -Text "$message" `
+                                                                      -ImageUrl "https://www.python.org/static/community_logos/python-powered-h-100x130.png"

--- a/.github/workflows/validate-manifest.yml
+++ b/.github/workflows/validate-manifest.yml
@@ -31,7 +31,7 @@ jobs:
     name: Check validation for failures 
     runs-on: ubuntu-latest
     needs: [validation]
-    if: success()
+    if: failure()
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/validate-manifest.yml
+++ b/.github/workflows/validate-manifest.yml
@@ -23,7 +23,7 @@ jobs:
           submodules: true
           
     - name: Validate python-versions manifest
-      run: .\helpers\packages-generation\manifest-validator.ps1 -ManifestUrl https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
+      run: .\helpers\packages-generation\manifest-validator.ps1 -ManifestUrl https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json -AccessToken ${{ secrets.GITHUB_TOKEN }}
 
   check_build:
     name: Check validation for failures 


### PR DESCRIPTION
In scope of this PR we moved manifest-validation pipeline from Azure DevOps to this repository.