### PR TITLE
Set the CFLAGS environment variable for python builder

### DIFF
--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -52,6 +52,7 @@ class macOSPythonBuilder : NixPythonBuilder {
             $configureString += " --enable-loadable-sqlite-extensions"
             $env:LDFLAGS += " -L$(brew --prefix sqlite3)/lib"
             $env:CFLAGS += " -I$(brew --prefix sqlite3)/include"
+            $env:CPPFLAGS += "-I$(brew --prefix sqlite3)/include"
         }
 
         Execute-Command -Command $configureString


### PR DESCRIPTION
In scope of this PR we are setting the CFLAGS environment variable for python builder to resolve `error: System version of SQLite does not support loadable extensions ` error.

Related issue: [#2670](https://github.com/actions/virtual-environments-internal/issues/2670)

Failed run: https://github.visualstudio.com/virtual-environments/_build/results?buildId=115840&view=results
Successful run: https://github.visualstudio.com/virtual-environments/_build/results?buildId=116052&view=results