### PR TITLE
When upgrading pip, don't warn there's a new version of pip available

### DIFF
--- a/installers/nix-setup-template.sh
+++ b/installers/nix-setup-template.sh
@@ -48,9 +48,9 @@ fi
 
 chmod +x ../python $PYTHON_MAJOR $PYTHON_MAJOR_DOT_MINOR $PYTHON_MAJORMINOR python
 
-echo "Upgrading PIP..."
+echo "Upgrading pip..."
 ./python -m ensurepip
-./python -m pip install --ignore-installed pip --no-warn-script-location
+./python -m pip install --ignore-installed pip --disable-pip-version-check --no-warn-script-location
 
 echo "Create complete file"
 touch $PYTHON_TOOLCACHE_VERSION_PATH/x64.complete


### PR DESCRIPTION
Fixes https://github.com/actions/setup-python/issues/233.

I often see "errors" like this when testing Python 3.10:

![image](https://user-images.githubusercontent.com/1324225/136704842-36c260b9-77cc-4a6f-bd7c-450b9a3fd5f8.png)
https://github.com/bridgecrewio/checkov/actions/runs/1325650057

> WARNING: You are using pip version 21.2.3; however, version 21.2.4 is available. You should consider upgrading via the '/opt/hostedtoolcache/Python/3.10.0/x64/bin/python -m pip install --upgrade pip' command.

Several problems here:

* It's a warning, but shown as an error ("2 errors" in screenshot). 

* The "error" doesn't fail the build (this is actually a good thing, but still confusing).

* There's nothing I can actually do about this, it happens during `actions/setup-python`.

* False warnings mean people start to ignore real warnings.

* And ironically it warns to upgrade pip at the same time it is actually upgrading pip!

---

Let's disable the warning/error using:

```
  --disable-pip-version-check
                              Don't periodically check PyPI to determine whether a new version of pip is available for
                              download. Implied with --no-index.
```

---

Local test, first install an old version and then test the install command:

# Before

```console
$ python -m pip install pip==21.2.3

Collecting pip==21.2.3
  Using cached pip-21.2.3-py3-none-any.whl (1.6 MB)
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 21.2.4
    Uninstalling pip-21.2.4:
      Successfully uninstalled pip-21.2.4
Successfully installed pip-21.2.3
$ python -m pip install --ignore-installed pip --no-warn-script-location
Collecting pip
  Using cached pip-21.2.4-py3-none-any.whl (1.6 MB)
Installing collected packages: pip
Successfully installed pip-21.2.4
WARNING: You are using pip version 21.2.3; however, version 21.2.4 is available.
You should consider upgrading via the '/Library/Frameworks/Python.framework/Versions/3.9/bin/python3 -m pip install --upgrade pip' command.
```

# After

```console
$ python -m pip install pip==21.2.3

Collecting pip==21.2.3
  Using cached pip-21.2.3-py3-none-any.whl (1.6 MB)
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 21.2.4
    Uninstalling pip-21.2.4:
      Successfully uninstalled pip-21.2.4
Successfully installed pip-21.2.3
$ python -m pip install --ignore-installed pip --disable-pip-version-check --no-warn-script-location
Collecting pip
  Using cached pip-21.2.4-py3-none-any.whl (1.6 MB)
Installing collected packages: pip
Successfully installed pip-21.2.4
```




