### PR TITLE
Fix python generation for 3.11

### DIFF
--- a/tests/python-tests.ps1
+++ b/tests/python-tests.ps1
@@ -24,7 +24,7 @@ function Analyze-MissingModules([string] $buildOutputLocation) {
         $module = $regexMatch.Groups[1].Value.Trim()
         Write-Host "Failed missing modules:"
         Write-Host $module
-        if ( ($module -eq "_tkinter") -and ( ($Version -like "3.10.0-beta*") -or ($Version -like "3.10.0-alpha*") ) ) {
+        if ( ($module -eq "_tkinter") -and ( [semver]"$($Version.Major).$($Version.Minor)" -ge [semver]"3.10" -and $Version.PreReleaseLabel ) ) {
           Write-Host "$module $Version ignored"
         } else {
           return 1

--- a/tests/sources/python-modules.py
+++ b/tests/sources/python-modules.py
@@ -261,6 +261,10 @@ if sys.version_info >= (3, 10):
     standard_library.remove('symbol')
     standard_library.remove('formatter')
 
+# 'binhex' module has been removed from Python 3.11
+if sys.version_info >= (3, 11):
+    standard_library.remove('binhex')
+
 # Remove tkinter and Easter eggs
 excluded_modules = [
     'antigravity',


### PR DESCRIPTION
In scope of this pull request we remove binhex from standard libraries, because it was removed from [python 3.11 ](https://docs.python.org/3.11/whatsnew/3.11.html#removed). Besides, we refactor check to skip error with `_tkinter` for alpha and beta versions starting from python 3.10. 
 - Related pull request: https://github.com/actions/python-versions/pull/88