### PR TITLE
Uptake of the latest changes for helpers submodule

### DIFF
--- a/.github/workflows/validate-manifest.yml
+++ b/.github/workflows/validate-manifest.yml
@@ -1,31 +1,32 @@
 name: Validate manifest
 
 on:
-   schedule:
-    - cron:  '0 8,20 * * *'
-    
-   pull_request:
-     branches:
+  schedule:
+    - cron: '0 8,20 * * *'
+
+  pull_request:
+    branches:
       - main
-     paths:
+    paths:
       - 'versions-manifest.json'
+
 env:
   TOOL_NAME: "Python"
+
 defaults:
   run:
     shell: pwsh
-    
+
 jobs:
   validation:
     runs-on: ubuntu-latest
-    
     steps:
-    - uses: actions/checkout@v2
-      with:
+      - uses: actions/checkout@v2
+        with:
           submodules: true
-          
-    - name: Validate python-versions manifest
-      run: .\helpers\packages-generation\manifest-validator.ps1 -ManifestPath '.\versions-manifest.json' -AccessToken ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate python-versions manifest
+        run: .\helpers\packages-generation\manifest-validator.ps1 -ManifestPath '.\versions-manifest.json'
 
   check_build:
     name: Check validation for failures 

--- a/.github/workflows/validate-manifest.yml
+++ b/.github/workflows/validate-manifest.yml
@@ -25,7 +25,7 @@ jobs:
           submodules: true
           
     - name: Validate python-versions manifest
-      run: .\helpers\packages-generation\manifest-validator.ps1 -ManifestUrl https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json -AccessToken ${{ secrets.GITHUB_TOKEN }}
+      run: .\helpers\packages-generation\manifest-validator.ps1 -ManifestPath '.\versions-manifest.json' -AccessToken ${{ secrets.GITHUB_TOKEN }}
 
   check_build:
     name: Check validation for failures 


### PR DESCRIPTION
# Description
This PR uptakes the latest changes for helpers submodule. These changes update logic of versions-manifest.json gathering for Validate manifest workflow runs. It allows usage of already synced up file instead of new one downloading by url. (https://github.com/actions/versions-package-tools/pull/39). 

#### Related issue: https://github.com/actions/virtual-environments-internal/issues/2800

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated