### PR TITLE
Migrate macOS pipelines to macOS-10.15

### DIFF
--- a/azure-pipelines/build-python-packages.yml
+++ b/azure-pipelines/build-python-packages.yml
@@ -6,7 +6,7 @@ stages:
 - stage: Build_Python_MacOS
   dependsOn: []
   variables:
-    VmImage: 'macOS-10.14'
+    VmImage: 'macOS-10.15'
     Platform: darwin
     Architecture: x64
   jobs:
@@ -16,7 +16,7 @@ stages:
   condition: succeeded()
   dependsOn: Build_Python_MacOS
   variables:
-    VmImage: 'macOS-10.14'
+    VmImage: 'macOS-10.15'
     Platform: darwin
     Architecture: x64
   jobs:

--- a/azure-pipelines/templates/test-job.yml
+++ b/azure-pipelines/templates/test-job.yml
@@ -1,6 +1,6 @@
 jobs:
 - job: Test_Python
-  pool: 
+  pool:
     name: Azure Pipelines
     vmImage: $(VmImage)
   variables:

--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -22,6 +22,13 @@ class macOSPythonBuilder : NixPythonBuilder {
         [string] $platform
     ) : Base($version, $architecture, $platform) { }
 
+    [void] PrepareEnvironment() {
+        <#
+        .SYNOPSIS
+        Prepare system environment by installing dependencies and required packages.
+        #>
+    }
+
     [void] Configure() {
         <#
         .SYNOPSIS
@@ -40,8 +47,8 @@ class macOSPythonBuilder : NixPythonBuilder {
         ### and then add the appropriate paths for the header and library files to configure command.
         ### Link to documentation (https://cpython-devguide.readthedocs.io/setup/#build-dependencies)
         if ($this.Version -lt "3.7.0") {
-            $env:LDFLAGS = "-L/usr/local/opt/openssl@1.1/lib"
-            $env:CFLAGS = "-I/usr/local/opt/openssl@1.1/include"
+            $env:LDFLAGS = "-L/usr/local/opt/openssl@1.1/lib -L/usr/local/opt/zlib/lib"
+            $env:CFLAGS = "-I/usr/local/opt/openssl@1.1/include -I/usr/local/opt/zlib/include"
         } else {
             $configureString += " --with-openssl=/usr/local/opt/openssl@1.1"
         }
@@ -56,16 +63,5 @@ class macOSPythonBuilder : NixPythonBuilder {
         }
 
         Execute-Command -Command $configureString
-    }
-
-    [void] PrepareEnvironment() {
-        <#
-        .SYNOPSIS
-        Prepare system environment by installing dependencies and required packages.
-        #>
-
-        ### reinstall header files to Avoid issue with X11 headers on Mojave
-        $pkgName = "/Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg"
-        Execute-Command -Command "sudo installer -pkg $pkgName -target /"
     }
 }


### PR DESCRIPTION
## Summary

As macOS-10.14 got deprecated we need to switch to 10.15 accordingly.
The `macOS_SDK_headers_for_macOS_10.14.pkg` package is no longer shipped with 10.15 so we have to symlink the `xlib.h` header file from the current SDK. Apart from that python 3.6.x needs zlib CFLAGS and LDFLAGS set accordingly (otherwise it is compiled without the compression algorithms support and tests are going to fail).

## Tested versions

Below are the results of the changes testing with the respective pipelines: 

3.6.x - https://github.visualstudio.com/virtual-environments/_build/results?buildId=120449&view=results
3.7.x - https://github.visualstudio.com/virtual-environments/_build/results?buildId=120450&view=results
3.8.x - https://github.visualstudio.com/virtual-environments/_build/results?buildId=120451&view=results
3.9.x - https://github.visualstudio.com/virtual-environments/_build/results?buildId=120452&view=results
3.10.x - https://github.visualstudio.com/virtual-environments/_build/results?buildId=120454&view=results

## Not tested / Does not work

2.7.x - Does not compile without hacks, I tried to play with the configure script options and managed to disable some deprecated modules, but some of them are unconditional and we would have to patch the `setup.py` file to get rid if them, it was discussed and decided not to rebuild 2.7.x anymore
3.5.x it is EOL,  does not make sense to rebuild it
3.10.1 - We are experiencing major troubles with the `tkinter` and `turtle` modules import, it is currently under investigation (though its failure does not block us, the same failure happened on macOS-10.14).

EDIT: given that lixft and libxext are now installed in the Catalina image there is no more need to symlink the xlib.h from the SDK as libxext is pulling libx11 (which has the header) as a mandatory dependency.