### PR TITLE
Skip sqlite module test for python3.11.0-alpha.3

### DIFF
--- a/tests/python-tests.ps1
+++ b/tests/python-tests.ps1
@@ -47,7 +47,7 @@ Describe "Tests" {
         "python ./sources/simple-test.py" | Should -ReturnZeroExitCode
     }
 
-    if ($Version -ge "3.2.0") {
+    if (($Version -ge "3.2.0") -and ($Version -ne "3.11.0-alpha.3")) {
         It "Check if sqlite3 module is installed" {
             "python ./sources/python-sqlite3.py" | Should -ReturnZeroExitCode
         }


### PR DESCRIPTION
`sqlite` module is currently broken in 3.11-alpha.3 on windows as it lacks `enable_load_extension` attrr in the `sqlite3.Connection` method. Lets skip the entire test now so we could add a version, then revisit the constraint later if situation improves.