### PR TITLE
Migrate windows pipelines to windows-2019

### DIFF
--- a/azure-pipelines/build-python-packages.yml
+++ b/azure-pipelines/build-python-packages.yml
@@ -63,7 +63,7 @@ stages:
 - stage: Build_Python_X64_Windows
   dependsOn: []
   variables:
-    VmImage: 'vs2017-win2016'
+    VmImage: 'windows-2019'
     Platform: win32
     Architecture: x64
   jobs:
@@ -73,7 +73,7 @@ stages:
   condition: succeeded()
   dependsOn: Build_Python_X64_Windows
   variables:
-    VmImage: 'vs2017-win2016'
+    VmImage: 'windows-2019'
     Platform: win32
     Architecture: x64
   jobs:
@@ -82,7 +82,7 @@ stages:
 - stage: Build_Python_x86_Windows
   dependsOn: []
   variables:
-    VmImage: 'vs2017-win2016'
+    VmImage: 'windows-2019'
     Platform: win32
     Architecture: x86
   jobs:
@@ -92,7 +92,7 @@ stages:
   condition: succeeded()
   dependsOn: Build_Python_x86_Windows
   variables:
-    VmImage: 'vs2017-win2016'
+    VmImage: 'windows-2019'
     Platform: win32
     Architecture: x86
   jobs:


### PR DESCRIPTION
 Windows 2016 support is EOL, so we need to take one step forward and move to 2019, downloadings/tests look good so no more edits needed.

Some successful pipilenes:

3.9.x - https://github.visualstudio.com/virtual-environments/_build/results?buildId=120614&view=results
3.10.x - https://github.visualstudio.com/virtual-environments/_build/results?buildId=120615&view=results
3.8.x - https://github.visualstudio.com/virtual-environments/_build/results?buildId=120616&view=results