### PR TITLE
Migrate build pipeline to Pester v5

### DIFF
--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -146,7 +146,7 @@ jobs:
 
       - name: Run tests
         run: |
-            Install-Module Pester -Force -Scope CurrentUser -RequiredVersion 5.3.1
+            Install-Module Pester -Force -Scope CurrentUser
             Import-Module Pester
             $pesterContainer = New-PesterContainer -Path './python-tests.ps1' -Data @{
                 Version="${{ env.VERSION }}";

--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -152,7 +152,7 @@ jobs:
                 Version="${{ env.VERSION }}";
                 Platform="${{ matrix.platform }}";
             }
-            Invoke-Pester -Container $pesterContainer -PassThru
+            $Result = Invoke-Pester -Container $pesterContainer -PassThru
             if ($Result.FailedCount -gt 0) {
               $host.SetShouldExit($Result.FailedCount)
               exit $Result.FailedCount

--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -146,16 +146,13 @@ jobs:
 
       - name: Run tests
         run: |
-            Install-Module Pester -Force -Scope CurrentUser -RequiredVersion 4.10.1
+            Install-Module Pester -Force -Scope CurrentUser -RequiredVersion 5.3.1
             Import-Module Pester
-            $pesterParams = @{
-              Path="./python-tests.ps1";
-              Parameters=@{
+            $pesterContainer = New-PesterContainer -Path './python-tests.ps1' -Data @{
                 Version="${{ env.VERSION }}";
                 Platform="${{ matrix.platform }}";
-              }
             }
-            $Result = Invoke-Pester -PassThru -Script $pesterParams
+            Invoke-Pester -Container $pesterContainer -PassThru
             if ($Result.FailedCount -gt 0) {
               $host.SetShouldExit($Result.FailedCount)
               exit $Result.FailedCount

--- a/tests/python-tests.ps1
+++ b/tests/python-tests.ps1
@@ -9,29 +9,31 @@ Import-Module (Join-Path $PSScriptRoot "../helpers/pester-extensions.psm1")
 Import-Module (Join-Path $PSScriptRoot "../helpers/common-helpers.psm1")
 Import-Module (Join-Path $PSScriptRoot "../builders/python-version.psm1")
 
-function Analyze-MissingModules([string] $buildOutputLocation) {
-    $searchStringStart = "Failed to build these modules:"
-    $searchStringEnd = "running build_scripts"
-    $pattern = "$searchStringStart(.*?)$searchStringEnd"
+BeforeAll {
+    function Analyze-MissingModules([string] $buildOutputLocation) {
+        $searchStringStart = "Failed to build these modules:"
+        $searchStringEnd = "running build_scripts"
+        $pattern = "$searchStringStart(.*?)$searchStringEnd"
 
-    $buildContent = Get-Content -Path $buildOutputLocation
-    $splitBuiltOutput = $buildContent -split "\n";
+        $buildContent = Get-Content -Path $buildOutputLocation
+        $splitBuiltOutput = $buildContent -split "\n";
 
-    ### Search for missing modules that are displayed between the search strings
-    $regexMatch = [regex]::match($SplitBuiltOutput, $Pattern)
-    if ($regexMatch.Success)
-    {
-        $module = $regexMatch.Groups[1].Value.Trim()
-        Write-Host "Failed missing modules:"
-        Write-Host $module
-        if ( ($module -eq "_tkinter") -and ( [semver]"$($Version.Major).$($Version.Minor)" -ge [semver]"3.10" -and $Version.PreReleaseLabel ) ) {
-          Write-Host "$module $Version ignored"
-        } else {
-          return 1
+        ### Search for missing modules that are displayed between the search strings
+        $regexMatch = [regex]::match($SplitBuiltOutput, $Pattern)
+        if ($regexMatch.Success)
+        {
+            $module = $regexMatch.Groups[1].Value.Trim()
+            Write-Host "Failed missing modules:"
+            Write-Host $module
+            if ( ($module -eq "_tkinter") -and ( [semver]"$($Version.Major).$($Version.Minor)" -ge [semver]"3.10" -and $Version.PreReleaseLabel ) ) {
+                Write-Host "$module $Version ignored"
+            } else {
+                return 1
+            }
         }
-    }
 
-    return 0
+        return 0
+    }
 }
 
 Describe "Tests" {


### PR DESCRIPTION
As requested lets move from Pester v4 to Pester v5 for testing. Newer version does not have an explicit ability to accept a user-defined script's arguments, so all the custom parameters must be put into a `Container` and then the  container must be passed to the `Invoke-Pester` call.
Apart from that, all the user-defined functions must be wrapped into the `BeforeAll` definition

Original issue: https://github.com/actions/virtual-environments-internal/issues/3205