### PR TITLE
Extend check for all alpha versions of 3.11 python

### DIFF
--- a/tests/python-tests.ps1
+++ b/tests/python-tests.ps1
@@ -49,7 +49,7 @@ Describe "Tests" {
         "python ./sources/simple-test.py" | Should -ReturnZeroExitCode
     }
 
-    if (($Version -ge "3.2.0") -and ($Version -ne "3.11.0-alpha.3")) {
+    if (($Version -ge "3.2.0") -and -not ([semver]"$($Version.Major).$($Version.Minor)" -eq [semver]"3.11" -and $Version.PreReleaseLabel)) {
         It "Check if sqlite3 module is installed" {
             "python ./sources/python-sqlite3.py" | Should -ReturnZeroExitCode
         }


### PR DESCRIPTION
In scope of this pull request we extend check for sqlite python 3.11 to skip sqlite's tests for all unstable versions of 3.11.
 - https://github.com/actions/python-versions/actions/runs/1750905151