### PR TITLE
Only run scheduled jobs on upstream

### DIFF
--- a/.github/workflows/get-python-versions.yml
+++ b/.github/workflows/get-python-versions.yml
@@ -12,6 +12,7 @@ defaults:
 
 jobs:
   find_new_versions:
+    if: github.repository_owner == 'actions'
     name: Find new versions
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/validate-manifest.yml
+++ b/.github/workflows/validate-manifest.yml
@@ -19,6 +19,7 @@ defaults:
 
 jobs:
   validation:
+    if: github.repository_owner == 'actions'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
There's no need to run these on forks and use up lots of resources.

<img width="959" alt="image" src="https://user-images.githubusercontent.com/1324225/157967401-9c887226-0fa1-4b2e-bf54-3a04d8b4b96f.png">

https://github.com/hugovk/python-versions/actions/workflows/validate-manifest.yml