### PR TITLE
Exclude tkinter and turtle for Python 3.11.0 alpha7 on Ubuntu 18.04

### DIFF
--- a/tests/sources/python-modules.py
+++ b/tests/sources/python-modules.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 
 import importlib
 import sys
+import platform
 
 # The Python standard library as of Python 3.0
 standard_library = [
@@ -264,6 +265,11 @@ if sys.version_info >= (3, 10):
 # 'binhex' module has been removed from Python 3.11
 if sys.version_info >= (3, 11):
     standard_library.remove('binhex')
+
+# Exclude tkinter and turtle for Python 3.11 alpha temporarily
+if sys.version_info >= (3, 11) and platform.system() == 'Linux' and '18.04' in platform.version():
+    standard_library.remove('tkinter')
+    standard_library.remove('turtle')
 
 # Remove tkinter and Easter eggs
 excluded_modules = [


### PR DESCRIPTION
Added temporary workaround for Python 3.11.0-alpha.7 and Ubuntu 18.04 runner: exclude tkinter and turtle modules from tests for this Python version.

Test build: https://github.com/vsafonkin/python-versions/actions/runs/2146875741

Internal issue: [link](https://github.com/actions/virtual-environments-internal/issues/3535) 