### PR TITLE
Document why we build from source on macOS

### DIFF
--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -7,6 +7,10 @@ class macOSPythonBuilder : NixPythonBuilder {
 
     .DESCRIPTION
     Contains methods that required to build macOS Python artifact from sources. Inherited from base NixPythonBuilder.
+    
+    While python.org provides precompiled binaries for macOS, switching to them risks breaking existing customers.
+    If we wanted to start using the official binaries instead of building from source, we should avoid changing previous versions
+    so we remain backwards compatible.
 
     .PARAMETER platform
     The full name of platform for which Python should be built.


### PR DESCRIPTION
On Windows we use the installers provided from python.org, while on Ubuntu we have to build from source because there is no installer.

While macOS reuses much of the build process for Ubuntu, I always forget why we don't switch over to the official binaries.  I chatted with @maxim-lobanov and he reminded me of the reason.