### PR TITLE
Disable universal2 macOS builds

### DIFF
--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -50,9 +50,10 @@ class macOSPythonBuilder : NixPythonBuilder {
         ### will never be used itself by a Github Actions runner but using a universal2 Python is the only way to build
         ### universal2 C extensions and wheels. This is supported by Python >= 3.10 and was backported to Python >=
         ### 3.9.1 and >= 3.8.10.
-        if ($this.Version -ge "3.8.10" -and $this.Version -ne "3.8.13" -and $this.Version -ne "3.9.0" ) {
-            $configureString += " --enable-universalsdk --with-universal-archs=universal2"
-        }
+        ### Disabled, discussion: https://github.com/actions/python-versions/pull/114
+        # if ($this.Version -ge "3.8.10" -and $this.Version -ne "3.8.13" -and $this.Version -ne "3.9.0" ) {
+        #     $configureString += " --enable-universalsdk --with-universal-archs=universal2"
+        # }
 
         ### OS X 10.11, Apple no longer provides header files for the deprecated system version of OpenSSL.
         ### Solution is to install these libraries from a third-party package manager,


### PR DESCRIPTION
Since the `universal2` build of python for macOS brought some breaking changes for customers, we need to disable it temporary.

See PR discussion: https://github.com/actions/python-versions/pull/114