### PR TITLE
Instal osx python from prebuilt packagese

### DIFF
--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -142,9 +142,9 @@ class macOSPythonBuilder : NixPythonBuilder {
         #>
 
         Write-Host "Build Python *$($this.Version)* [$($this.Architecture)]"
-        Write-Host ($this.Version -ge "3.11.0") 
+        Write-Host ($this.Version -ge 3.11.0) 
 
-        if ($this.Version -ge "3.11.0") {
+        if ($this.Version -ge 3.11.0) {
             Write-Host "Download Python $($this.Version) [$($this.Architecture)] package..."
             $this.DownloadPkg()
 

--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -1,6 +1,6 @@
-using module "./python-builder.psm1"
+using module "./nix-python-builder.psm1"
 
-class macOSPythonBuilder : PythonBuilder {
+class macOSPythonBuilder : NixPythonBuilder {
     <#
     .SYNOPSIS
     MacOS Python builder class.
@@ -20,43 +20,71 @@ class macOSPythonBuilder : PythonBuilder {
 
     #>
 
-    [string] $InstallationTemplateName
-    [string] $InstallationScriptName
-    [string] $OutputArtifactName
-
     macOSPythonBuilder(
         [semver] $version,
         [string] $architecture,
         [string] $platform
-    ) : Base($version, $architecture, $platform) {
-        $this.InstallationTemplateName = "macos-setup-template.ps1"
-        $this.InstallationScriptName = "setup.sh"
-        $this.OutputArtifactName = "python-$Version-$Platform-$Architecture.zip"
-    }
+    ) : Base($version, $architecture, $platform) { }
 
-    [string] GetPythonExtension() {
+    [void] PrepareEnvironment() {
         <#
         .SYNOPSIS
-        Return extension for required version of Python package. 
+        Prepare system environment by installing dependencies and required packages.
         #>
-
-        $extension = ".pkg"
-
-        return $extension
     }
 
-    [string] GetArchitectureExtension() {
+    [void] Configure() {
         <#
         .SYNOPSIS
-        Return architecture suffix for Python package. 
+        Execute configure script with required parameters.
         #>
 
-        $ArchitectureExtension = "-macos11"
+        $pythonBinariesLocation = $this.GetFullPythonToolcacheLocation()
+        $configureString = "./configure"
+        $configureString += " --prefix=$pythonBinariesLocation"
+        $configureString += " --enable-optimizations"
+        $configureString += " --enable-shared"
+        $configureString += " --with-lto"
 
-        return $ArchitectureExtension
+        ### For Python versions which support it, compile a universal2 (arm64 + x86_64 hybrid) build. The arm64 slice
+        ### will never be used itself by a Github Actions runner but using a universal2 Python is the only way to build
+        ### universal2 C extensions and wheels. This is supported by Python >= 3.10 and was backported to Python >=
+        ### 3.9.1 and >= 3.8.10.
+        ### Disabled, discussion: https://github.com/actions/python-versions/pull/114
+        # if ($this.Version -ge "3.8.10" -and $this.Version -ne "3.8.13" -and $this.Version -ne "3.9.0" ) {
+        #     $configureString += " --enable-universalsdk --with-universal-archs=universal2"
+        # }
+
+        ### OS X 10.11, Apple no longer provides header files for the deprecated system version of OpenSSL.
+        ### Solution is to install these libraries from a third-party package manager,
+        ### and then add the appropriate paths for the header and library files to configure command.
+        ### Link to documentation (https://cpython-devguide.readthedocs.io/setup/#build-dependencies)
+        if ($this.Version -lt "3.7.0") {
+            $env:LDFLAGS = "-L/usr/local/opt/openssl@1.1/lib -L/usr/local/opt/zlib/lib"
+            $env:CFLAGS = "-I/usr/local/opt/openssl@1.1/include -I/usr/local/opt/zlib/include"
+        } else {
+            $configureString += " --with-openssl=/usr/local/opt/openssl@1.1"
+            if ($this.Version -gt "3.7.12") {
+                $configureString += " --with-tcltk-includes='-I /usr/local/opt/tcl-tk/include' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6'"
+	    }
+        }
+
+        ### Compile with support of loadable sqlite extensions. Unavailable for Python 2.*
+        ### Link to documentation (https://docs.python.org/3/library/sqlite3.html#sqlite3.Connection.enable_load_extension)
+        if ($this.Version -ge "3.2.0") {
+            $configureString += " --enable-loadable-sqlite-extensions"
+            $env:LDFLAGS += " -L$(brew --prefix sqlite3)/lib"
+            $env:CFLAGS += " -I$(brew --prefix sqlite3)/include"
+            $env:CPPFLAGS += "-I$(brew --prefix sqlite3)/include"
+        }
+
+        Write-Host "The passed configure options are: "
+        Write-Host $configureString
+
+        Execute-Command -Command $configureString
     }
 
-    [uri] GetSourceUri() {
+    [uri] GetPkgUri() {
         <#
         .SYNOPSIS
         Get base Python URI and return complete URI for Python installation executable.
@@ -65,55 +93,46 @@ class macOSPythonBuilder : PythonBuilder {
         $base = $this.GetBaseUri()
         $versionName = $this.GetBaseVersion()
         $nativeVersion = Convert-Version -version $this.Version
-        $architecture = $this.GetArchitectureExtension()
-        $extension = $this.GetPythonExtension()
+        $architecture = "-macos11"
+        $extension = ".pkg"
 
         $uri = "${base}/${versionName}/python-${nativeVersion}${architecture}${extension}"
 
         return $uri
     }
 
-    [string] Download() {
+    [string] DownloadPkg() {
         <#
         .SYNOPSIS
         Download Python installation executable into artifact location.
         #>
 
-        $sourceUri = $this.GetSourceUri()
+        $pkgUri = $this.GetPkgUri()
 
-        Write-Host "Sources URI: $sourceUri"
-        $sourcesLocation = Download-File -Uri $sourceUri -OutputFolder $this.WorkFolderLocation
-        Write-Debug "Done; Sources location: $sourcesLocation"
+        Write-Host "Sources URI: $pkgUri"
+        $pkgLocation = Download-File -Uri $pkgUri -OutputFolder $this.WorkFolderLocation
+        Write-Debug "Done; Package location: $pkgLocation"
 
-        return $sourcesLocation
+        return $pkgLocation
     }
 
-    [void] CreateInstallationScript() {
+    [void] CreateInstallationScriptPkg() {
         <#
         .SYNOPSIS
         Create Python artifact installation script based on specified template.
         #>
 
-        $sourceUri = $this.GetSourceUri()
-        $pythonExecName = [IO.path]::GetFileName($sourceUri.AbsoluteUri)
         $installationTemplateLocation = Join-Path -Path $this.InstallationTemplatesLocation -ChildPath $this.InstallationTemplateName
         $installationTemplateContent = Get-Content -Path $installationTemplateLocation -Raw
-        $installationScriptLocation = New-Item -Path $this.WorkFolderLocation -Name $this.InstallationScriptName -ItemType File
+        $installationScriptLocation = New-Item -Path $this.WorkFolderLocation -Name "macos-pkg-setup-template.sh" -ItemType File
 
         $variablesToReplace = @{
-            "{{__ARCHITECTURE__}}" = $this.Architecture;
-            "{{__VERSION__}}" = $this.Version;
-            "{{__PYTHON_EXEC_NAME__}}" = $pythonExecName
+            "{{__VERSION_FULL__}}" = $this.Version;
         }
 
         $variablesToReplace.keys | ForEach-Object { $installationTemplateContent = $installationTemplateContent.Replace($_, $variablesToReplace[$_]) }
         $installationTemplateContent | Out-File -FilePath $installationScriptLocation
         Write-Debug "Done; Installation script location: $installationScriptLocation)"
-    }
-
-    [void] ArchiveArtifact() {
-        $OutputPath = Join-Path $this.ArtifactFolderLocation $this.OutputArtifactName
-        Create-SevenZipArchive -SourceFolder $this.WorkFolderLocation -ArchivePath $OutputPath
     }
 
     [void] Build() {
@@ -122,11 +141,19 @@ class macOSPythonBuilder : PythonBuilder {
         Generates Python artifact from downloaded Python installation executable.
         #>
 
-        Write-Host "Download Python $($this.Version) [$($this.Architecture)] executable..."
-        $this.Download()
+        if ($this.Version -ge "3.11.0") {
+            Write-Host "Download Python $($this.Version) [$($this.Architecture)] package..."
+            $this.DownloadPkg()
 
-        Write-Host "Create installation script..."
-        $this.CreateInstallationScript()
+            Write-Host "Create installation script..."
+            $this.CreateInstallationScriptPkg()
+        } else {
+            Write-Host "Download Python $($this.Version) [$($this.Architecture)] executable..."
+            $this.Download()
+
+            Write-Host "Create installation script..."
+            $this.CreateInstallationScript()
+        }
 
         Write-Host "Archive artifact"
         $this.ArchiveArtifact()

--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -151,7 +151,7 @@ class macOSPythonBuilder : NixPythonBuilder {
             Write-Host "Create installation script..."
             $this.CreateInstallationScriptPkg()
         } else {
-            super().Build()
+            ([NixPythonBuilder]$this).Build()
         }
 
         Write-Host "Archive artifact"

--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -141,7 +141,8 @@ class macOSPythonBuilder : NixPythonBuilder {
         Generates Python artifact from downloaded Python installation executable.
         #>
 
-        Write-Host "Build Python $($this.Version) [$($this.Architecture)]"
+        Write-Host "Build Python *$($this.Version)* [$($this.Architecture)]"
+        Write-Host ($this.Version -ge "3.11.0") 
 
         if ($this.Version -ge "3.11.0") {
             Write-Host "Download Python $($this.Version) [$($this.Architecture)] package..."

--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -151,11 +151,7 @@ class macOSPythonBuilder : NixPythonBuilder {
             Write-Host "Create installation script..."
             $this.CreateInstallationScriptPkg()
         } else {
-            Write-Host "Download Python $($this.Version) [$($this.Architecture)] executable..."
-            $this.Download()
-
-            Write-Host "Create installation script..."
-            $this.CreateInstallationScript()
+            super().Build()
         }
 
         Write-Host "Archive artifact"

--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -141,6 +141,8 @@ class macOSPythonBuilder : NixPythonBuilder {
         Generates Python artifact from downloaded Python installation executable.
         #>
 
+        Write-Host "Build Python $($this.Version) [$($this.Architecture)]"
+
         if ($this.Version -ge "3.11.0") {
             Write-Host "Download Python $($this.Version) [$($this.Architecture)] package..."
             $this.DownloadPkg()

--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -142,7 +142,7 @@ class macOSPythonBuilder : NixPythonBuilder {
         Generates Python artifact from downloaded Python installation executable.
         #>
 
-        $PkgVersion = [semver]"3.11.0"
+        $PkgVersion = [semver]"3.11.0-beta.1"
 
         if ($this.Version -ge $PkgVersion) {
             Write-Host "Download Python $($this.Version) [$($this.Architecture)] package..."

--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -142,7 +142,9 @@ class macOSPythonBuilder : NixPythonBuilder {
         Generates Python artifact from downloaded Python installation executable.
         #>
 
-        if ($this.Version -ge 3.11.0) {
+        $PkgVersion = [semver]"3.11.0"
+
+        if ($this.Version -ge $PkgVersion) {
             Write-Host "Download Python $($this.Version) [$($this.Architecture)] package..."
             $this.DownloadPkg()
 

--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -84,19 +84,32 @@ class macOSPythonBuilder : NixPythonBuilder {
         Execute-Command -Command $configureString
     }
 
-    [uri] GetPkgUri() {
+    [string] GetPkgName() {
         <#
         .SYNOPSIS
-        Get base Python URI and return complete URI for Python installation executable.
+        Return Python installation Package.
         #>
 
-        $base = $this.GetBaseUri()
-        $versionName = $this.GetBaseVersion()
         $nativeVersion = Convert-Version -version $this.Version
         $architecture = "-macos11"
         $extension = ".pkg"
 
-        $uri = "${base}/${versionName}/python-${nativeVersion}${architecture}${extension}"
+        $pkg = "python-${nativeVersion}${architecture}${extension}"
+
+        return $pkg
+    }
+
+    [uri] GetPkgUri() {
+        <#
+        .SYNOPSIS
+        Get base Python URI and return complete URI for Python installation package.
+        #>
+
+        $base = $this.GetBaseUri()
+        $versionName = $this.GetBaseVersion()
+        $pkg = $this.GetPkgName()
+
+        $uri = "${base}/${versionName}/${pkg}"
 
         return $uri
     }
@@ -129,6 +142,7 @@ class macOSPythonBuilder : NixPythonBuilder {
 
         $variablesToReplace = @{
             "{{__VERSION_FULL__}}" = $this.Version;
+            "{{__PKG_NAME__}}" = $this.GetPkgName();
         }
 
         $variablesToReplace.keys | ForEach-Object { $installationTemplateContent = $installationTemplateContent.Replace($_, $variablesToReplace[$_]) }

--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -113,6 +113,7 @@ class macOSPythonBuilder : NixPythonBuilder {
         $pkgLocation = Download-File -Uri $pkgUri -OutputFolder $this.WorkFolderLocation
         Write-Debug "Done; Package location: $pkgLocation"
 
+        New-Item "build_output.txt"
         return $pkgLocation
     }
 
@@ -140,9 +141,6 @@ class macOSPythonBuilder : NixPythonBuilder {
         .SYNOPSIS
         Generates Python artifact from downloaded Python installation executable.
         #>
-
-        Write-Host "Build Python *$($this.Version)* [$($this.Architecture)]"
-        Write-Host ($this.Version -ge 3.11.0) 
 
         if ($this.Version -ge 3.11.0) {
             Write-Host "Download Python $($this.Version) [$($this.Architecture)] package..."

--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -113,7 +113,7 @@ class macOSPythonBuilder : NixPythonBuilder {
         $pkgLocation = Download-File -Uri $pkgUri -OutputFolder $this.WorkFolderLocation
         Write-Debug "Done; Package location: $pkgLocation"
 
-        New-Item "build_output.txt"
+        New-Item -Path $this.WorkFolderLocation -Name "build_output.txt"  -ItemType File
         return $pkgLocation
     }
 
@@ -123,9 +123,9 @@ class macOSPythonBuilder : NixPythonBuilder {
         Create Python artifact installation script based on specified template.
         #>
 
-        $installationTemplateLocation = Join-Path -Path $this.InstallationTemplatesLocation -ChildPath $this.InstallationTemplateName
+        $installationTemplateLocation = Join-Path -Path $this.InstallationTemplatesLocation -ChildPath "macos-pkg-setup-template.sh"
         $installationTemplateContent = Get-Content -Path $installationTemplateLocation -Raw
-        $installationScriptLocation = New-Item -Path $this.WorkFolderLocation -Name "macos-pkg-setup-template.sh" -ItemType File
+        $installationScriptLocation = New-Item -Path $this.WorkFolderLocation -Name $this.InstallationScriptName  -ItemType File
 
         $variablesToReplace = @{
             "{{__VERSION_FULL__}}" = $this.Version;

--- a/installers/macos-pkg-setup-template.sh
+++ b/installers/macos-pkg-setup-template.sh
@@ -37,7 +37,6 @@ fi
 
 echo "Install Python binaries from prebuilt package"
 sudo installer -pkg $PYTHON_PKG_NAME -target /
-rm $PYTHON_TOOLCACHE_VERSION_ARCH_PATH/setup.sh
 
 echo "Create hostedtoolcach symlinks (Required for the backward compatibility)"
 echo "Create Python $PYTHON_FULL_VERSION folder"

--- a/installers/macos-pkg-setup-template.sh
+++ b/installers/macos-pkg-setup-template.sh
@@ -1,6 +1,7 @@
 set -e
 
 PYTHON_FULL_VERSION="{{__VERSION_FULL__}}"
+PYTHON_PKG_NAME="{{__PKG_NAME__}}"
 MAJOR_VERSION=$(echo $PYTHON_FULL_VERSION | cut -d '.' -f 1)
 MINOR_VERSION=$(echo $PYTHON_FULL_VERSION | cut -d '.' -f 2)
 
@@ -35,7 +36,7 @@ else
 fi
 
 echo "Install Python binaries from prebuilt package"
-sudo installer -pkg "python-${PYTHON_FULL_VERSION}-macos11.pkg" -target /
+sudo installer -pkg $PYTHON_PKG_NAME -target /
 rm $PYTHON_TOOLCACHE_VERSION_ARCH_PATH/setup.sh
 
 echo "Create hostedtoolcach symlinks (Required for the backward compatibility)"

--- a/installers/macos-pkg-setup-template.sh
+++ b/installers/macos-pkg-setup-template.sh
@@ -19,6 +19,7 @@ fi
 PYTHON_TOOLCACHE_PATH=$TOOLCACHE_ROOT/Python
 PYTHON_TOOLCACHE_VERSION_PATH=$PYTHON_TOOLCACHE_PATH/$PYTHON_FULL_VERSION
 PYTHON_TOOLCACHE_VERSION_ARCH_PATH=$PYTHON_TOOLCACHE_VERSION_PATH/x64
+PYTHON_FRAMEWORK_PATH="/Library/Frameworks/Python.framework/Versions/${MAJOR_VERSION}.${MINOR_VERSION}"
 
 echo "Check if Python hostedtoolcache folder exist..."
 if [ ! -d $PYTHON_TOOLCACHE_PATH ]; then
@@ -43,10 +44,10 @@ echo "Create Python $PYTHON_FULL_VERSION folder"
 mkdir -p $PYTHON_TOOLCACHE_VERSION_ARCH_PATH
 cd $PYTHON_TOOLCACHE_VERSION_ARCH_PATH
 
-ln -s /Library/Frameworks/Python.framework/Versions/${MAJOR_VERSION}.${MINOR_VERSION}/bin bin
-ln -s /Library/Frameworks/Python.framework/Versions/${MAJOR_VERSION}.${MINOR_VERSION}/include include
-ln -s /Library/Frameworks/Python.framework/Versions/${MAJOR_VERSION}.${MINOR_VERSION}/share share
-ln -s /Library/Frameworks/Python.framework/Versions/${MAJOR_VERSION}.${MINOR_VERSION}/lib lib
+ln -s "${PYTHON_FRAMEWORK_PATH}/bin" bin
+ln -s "${PYTHON_FRAMEWORK_PATH}/include" include
+ln -s "${PYTHON_FRAMEWORK_PATH}/share" share
+ln -s "${PYTHON_FRAMEWORK_PATH}/lib" lib
 
 echo "Create additional symlinks (Required for the UsePythonVersion Azure Pipelines task and the setup-python GitHub Action)"
 ln -s ./bin/$PYTHON_MAJOR_DOT_MINOR python

--- a/installers/macos-pkg-setup-template.sh
+++ b/installers/macos-pkg-setup-template.sh
@@ -23,23 +23,26 @@ echo "Check if Python hostedtoolcache folder exist..."
 if [ ! -d $PYTHON_TOOLCACHE_PATH ]; then
     echo "Creating Python hostedtoolcache folder..."
     mkdir -p $PYTHON_TOOLCACHE_PATH
-elif [ -d $PYTHON_TOOLCACHE_VERSION_PATH ]; then
-    # TODO: remove ALL other directories for same MAJOR_VERSION.$MINOR_VERSION
-    echo "Deleting Python $PYTHON_FULL_VERSION"
-    rm -rf $PYTHON_TOOLCACHE_VERSION_PATH
+else
+    # remove ALL other directories for same major.minor python versions
+    find $PYTHON_TOOLCACHE_PATH -name "${MAJOR_VERSION}.${MINOR_VERSION}.*"|while read python_version;do
+        python_version_x64="$python_version/x64"
+        if [ -e "$python_version_x64" ];then
+            echo "Deleting Python $python_version_x64"
+            rm -rf "$python_version_x64"
+        fi
+    done
 fi
 
-echo "Create Python $PYTHON_FULL_VERSION folder"
-mkdir -p $PYTHON_TOOLCACHE_VERSION_ARCH_PATH
-
-echo "Copy Python binaries to hostedtoolcache folder"
-#cp -R ./* $PYTHON_TOOLCACHE_VERSION_ARCH_PATH
+echo "Install Python binaries from prebuilt package"
 sudo installer -pkg "python-${PYTHON_FULL_VERSION}-macos11.pkg" -target /
 rm $PYTHON_TOOLCACHE_VERSION_ARCH_PATH/setup.sh
 
+echo "Create hostedtoolcach symlinks (Required for the backward compatibility)"
+echo "Create Python $PYTHON_FULL_VERSION folder"
+mkdir -p $PYTHON_TOOLCACHE_VERSION_ARCH_PATH
 cd $PYTHON_TOOLCACHE_VERSION_ARCH_PATH
 
-echo "Create hostedtoolcach symlinks (Required for the backward compatibility)"
 ln -s /Library/Frameworks/Python.framework/Versions/${MAJOR_VERSION}.${MINOR_VERSION}/bin bin
 ln -s /Library/Frameworks/Python.framework/Versions/${MAJOR_VERSION}.${MINOR_VERSION}/include include
 ln -s /Library/Frameworks/Python.framework/Versions/${MAJOR_VERSION}.${MINOR_VERSION}/share share

--- a/installers/macos-pkg-setup-template.sh
+++ b/installers/macos-pkg-setup-template.sh
@@ -7,7 +7,7 @@ MINOR_VERSION=$(echo $PYTHON_FULL_VERSION | cut -d '.' -f 2)
 
 PYTHON_MAJOR=python$MAJOR_VERSION
 PYTHON_MAJOR_DOT_MINOR=python$MAJOR_VERSION.$MINOR_VERSION
-PYTHON_MAJORMINOR=python$MAJOR_VERSION$MINOR_VERSION
+PYTHON_MAJOR_MINOR=python$MAJOR_VERSION$MINOR_VERSION
 
 if [ -z ${AGENT_TOOLSDIRECTORY+x} ]; then
     # No AGENT_TOOLSDIRECTORY on GitHub images
@@ -52,12 +52,12 @@ echo "Create additional symlinks (Required for the UsePythonVersion Azure Pipeli
 ln -s ./bin/$PYTHON_MAJOR_DOT_MINOR python
 
 cd bin/
-ln -s $PYTHON_MAJOR_DOT_MINOR $PYTHON_MAJORMINOR
+ln -s $PYTHON_MAJOR_DOT_MINOR $PYTHON_MAJOR_MINOR
 if [ ! -f python ]; then
     ln -s $PYTHON_MAJOR_DOT_MINOR python
 fi
 
-chmod +x ../python $PYTHON_MAJOR $PYTHON_MAJOR_DOT_MINOR $PYTHON_MAJORMINOR python
+chmod +x ../python $PYTHON_MAJOR $PYTHON_MAJOR_DOT_MINOR $PYTHON_MAJOR_MINOR python
 
 echo "Upgrading pip..."
 ./python -m ensurepip

--- a/installers/macos-setup-template.sh
+++ b/installers/macos-setup-template.sh
@@ -1,0 +1,64 @@
+set -e
+
+PYTHON_FULL_VERSION="{{__VERSION_FULL__}}"
+MAJOR_VERSION=$(echo $PYTHON_FULL_VERSION | cut -d '.' -f 1)
+MINOR_VERSION=$(echo $PYTHON_FULL_VERSION | cut -d '.' -f 2)
+
+PYTHON_MAJOR=python$MAJOR_VERSION
+PYTHON_MAJOR_DOT_MINOR=python$MAJOR_VERSION.$MINOR_VERSION
+PYTHON_MAJORMINOR=python$MAJOR_VERSION$MINOR_VERSION
+
+if [ -z ${AGENT_TOOLSDIRECTORY+x} ]; then
+    # No AGENT_TOOLSDIRECTORY on GitHub images
+    TOOLCACHE_ROOT=$RUNNER_TOOL_CACHE
+else
+    TOOLCACHE_ROOT=$AGENT_TOOLSDIRECTORY
+fi
+
+PYTHON_TOOLCACHE_PATH=$TOOLCACHE_ROOT/Python
+PYTHON_TOOLCACHE_VERSION_PATH=$PYTHON_TOOLCACHE_PATH/$PYTHON_FULL_VERSION
+PYTHON_TOOLCACHE_VERSION_ARCH_PATH=$PYTHON_TOOLCACHE_VERSION_PATH/x64
+
+echo "Check if Python hostedtoolcache folder exist..."
+if [ ! -d $PYTHON_TOOLCACHE_PATH ]; then
+    echo "Creating Python hostedtoolcache folder..."
+    mkdir -p $PYTHON_TOOLCACHE_PATH
+elif [ -d $PYTHON_TOOLCACHE_VERSION_PATH ]; then
+    # TODO: remove ALL other directories for same MAJOR_VERSION.$MINOR_VERSION
+    echo "Deleting Python $PYTHON_FULL_VERSION"
+    rm -rf $PYTHON_TOOLCACHE_VERSION_PATH
+fi
+
+echo "Create Python $PYTHON_FULL_VERSION folder"
+mkdir -p $PYTHON_TOOLCACHE_VERSION_ARCH_PATH
+
+echo "Copy Python binaries to hostedtoolcache folder"
+#cp -R ./* $PYTHON_TOOLCACHE_VERSION_ARCH_PATH
+sudo installer -pkg "python-${PYTHON_FULL_VERSION}-macos11.pkg" -target /
+rm $PYTHON_TOOLCACHE_VERSION_ARCH_PATH/setup.sh
+
+cd $PYTHON_TOOLCACHE_VERSION_ARCH_PATH
+
+echo "Create hostedtoolcach symlinks (Required for the backward compatibility)"
+ln -s /Library/Frameworks/Python.framework/Versions/${MAJOR_VERSION}.${MINOR_VERSION}/bin bin
+ln -s /Library/Frameworks/Python.framework/Versions/${MAJOR_VERSION}.${MINOR_VERSION}/include include
+ln -s /Library/Frameworks/Python.framework/Versions/${MAJOR_VERSION}.${MINOR_VERSION}/share share
+ln -s /Library/Frameworks/Python.framework/Versions/${MAJOR_VERSION}.${MINOR_VERSION}/lib lib
+
+echo "Create additional symlinks (Required for the UsePythonVersion Azure Pipelines task and the setup-python GitHub Action)"
+ln -s ./bin/$PYTHON_MAJOR_DOT_MINOR python
+
+cd bin/
+ln -s $PYTHON_MAJOR_DOT_MINOR $PYTHON_MAJORMINOR
+if [ ! -f python ]; then
+    ln -s $PYTHON_MAJOR_DOT_MINOR python
+fi
+
+chmod +x ../python $PYTHON_MAJOR $PYTHON_MAJOR_DOT_MINOR $PYTHON_MAJORMINOR python
+
+echo "Upgrading pip..."
+./python -m ensurepip
+./python -m pip install --ignore-installed pip --disable-pip-version-check --no-warn-script-location
+
+echo "Create complete file"
+touch $PYTHON_TOOLCACHE_VERSION_PATH/x64.complete

--- a/tests/sources/python-config-test.py
+++ b/tests/sources/python-config-test.py
@@ -27,9 +27,9 @@ if os_type == 'Linux': expected_ld_library_extension = 'so'
 if os_type == 'Darwin': expected_ld_library_extension = 'dylib'
 
 if pkg_installer:
-    expected_lib_dir_path = '/Library/Frameworks/Python.framework/Versions/{0}.{1}/lib'.format(version_major, version_minor)
+    expected_lib_dir_path = f'/Library/Frameworks/Python.framework/Versions/{version_major}.{version_minor}/lib'
 else:
-    expected_lib_dir_path = '{0}/Python/{1}/x64/lib'.format(os.getenv("AGENT_TOOLSDIRECTORY"), version)
+    expected_lib_dir_path = f'{os.getenv("AGENT_TOOLSDIRECTORY")}/Python/{version}/x64/lib'
 
 # Check modules
 ### Validate libraries path

--- a/tests/sources/python-config-test.py
+++ b/tests/sources/python-config-test.py
@@ -4,11 +4,15 @@ import sysconfig
 import sys
 import platform
 import os
+import semver
 
 # Define variables
 os_type = platform.system()
 version = sys.argv[1]
 nativeVersion = sys.argv[2]
+
+version_sv = semver.VersionInfo.parse(version)
+pkg_installer = version_sv.major > 3 or version_sv.major == 3 and version_sv.minor >= 11
 
 lib_dir_path = sysconfig.get_config_var('LIBDIR')
 ld_library_name = sysconfig.get_config_var('LDLIBRARY')
@@ -19,7 +23,11 @@ have_libreadline = sysconfig.get_config_var("HAVE_LIBREADLINE")
 ### Define expected variables
 if os_type == 'Linux': expected_ld_library_extension = 'so'
 if os_type == 'Darwin': expected_ld_library_extension = 'dylib'
-expected_lib_dir_path = '{0}/Python/{1}/x64/lib'.format(os.getenv("AGENT_TOOLSDIRECTORY"), version)
+
+if pkg_installer:
+    expected_lib_dir_path = '/Library/Frameworks/Python.framework/Versions/{0}.{1}/lib'.format(version_sv.major, version_sv.minor)
+else:
+    expected_lib_dir_path = '{0}/Python/{1}/x64/lib'.format(os.getenv("AGENT_TOOLSDIRECTORY"), version)
 
 # Check modules
 ### Validate libraries path

--- a/tests/sources/python-config-test.py
+++ b/tests/sources/python-config-test.py
@@ -14,7 +14,7 @@ versions=version.split(".")
 version_major=int(versions[0])
 version_minor=int(versions[1])
 
-pkg_installer = os_type == 'Darwin' and (version_major > 3 or version_major == 3 and version_minor >= 11)
+pkg_installer = os_type == 'Darwin' and (version_major == 3 and version_minor >= 11)
 
 lib_dir_path = sysconfig.get_config_var('LIBDIR')
 ld_library_name = sysconfig.get_config_var('LDLIBRARY')


### PR DESCRIPTION
issue: https://github.com/actions/runner-images-internal/issues/4053

 1.  key changes of `builders/macos-python-builder.psm1` is to replace build from the source with installing from the .pkg file for python >= 3.11.1 and generate `setup.sh` from `macos-pkg-setup-template.sh`
 
 2. key features of  new `installers/macos-pkg-setup-template.sh`
         - runs pkg installer 
         - remove the python directories with the same major.minor from /opt/hostedtoolcache(*)
         - create major.minor.path in /opt/hostedtoolcache and add links to the default python installation
 
 * - unfortunately all the patch-versions use the same default major.minor default installation path 
 
 python-3.10.6 is installed into `/Library/Frameworks/Python.framework/Versions/3.10` and `python-3.10.5` is installed under the same `/Library/Frameworks/Python.framework/Versions/3.10` root. This is why the links created into /opt/hostedtoolcache must be removed if antother major.minor.patch version installed
 