### PR TITLE
fix: setup OpenSSL certificates in `macos-pkg-setup-template.sh`

### DIFF
--- a/installers/macos-pkg-setup-template.sh
+++ b/installers/macos-pkg-setup-template.sh
@@ -20,6 +20,7 @@ PYTHON_TOOLCACHE_PATH=$TOOLCACHE_ROOT/Python
 PYTHON_TOOLCACHE_VERSION_PATH=$PYTHON_TOOLCACHE_PATH/$PYTHON_FULL_VERSION
 PYTHON_TOOLCACHE_VERSION_ARCH_PATH=$PYTHON_TOOLCACHE_VERSION_PATH/x64
 PYTHON_FRAMEWORK_PATH="/Library/Frameworks/Python.framework/Versions/${MAJOR_VERSION}.${MINOR_VERSION}"
+PYTHON_APPLICATION_PATH="/Applications/Python ${MAJOR_VERSION}.${MINOR_VERSION}"
 
 echo "Check if Python hostedtoolcache folder exist..."
 if [ ! -d $PYTHON_TOOLCACHE_PATH ]; then
@@ -63,6 +64,9 @@ chmod +x ../python $PYTHON_MAJOR $PYTHON_MAJOR_DOT_MINOR $PYTHON_MAJOR_MINOR pyt
 echo "Upgrading pip..."
 ./python -m ensurepip
 ./python -m pip install --ignore-installed pip --disable-pip-version-check --no-warn-script-location
+
+echo "Install OpenSSL certificates"
+sh -e "${PYTHON_APPLICATION_PATH}/Install Certificates.command"
 
 echo "Create complete file"
 touch $PYTHON_TOOLCACHE_VERSION_PATH/x64.complete

--- a/tests/python-tests.ps1
+++ b/tests/python-tests.ps1
@@ -96,4 +96,8 @@ Describe "Tests" {
             "./dist/simple-test" | Should -ReturnZeroExitCode
         }
     }
+
+    It "Check urlopen with HTTPS works" {
+        "python ./sources/python-urlopen-https.py" | Should -ReturnZeroExitCode
+    }
 }

--- a/tests/sources/python-urlopen-https.py
+++ b/tests/sources/python-urlopen-https.py
@@ -1,0 +1,10 @@
+import sys
+
+if sys.version_info[0] == 2:
+    from urllib2 import urlopen
+else:
+    from urllib.request import urlopen
+
+response = urlopen("https://raw.githubusercontent.com/actions/python-versions/c641695f6a07526c18f10e374e503e649fef9427/.gitignore")
+data = response.read()
+assert len(data) == 140, len(data)


### PR DESCRIPTION
The macOS pkg installer does not setup default certificates for OpenSSL.
A script is provided by the macOS pkg installer to setup those using the certifi PyPI package.
Let's run this script as part of the setup template in order to be able to do HTTPS downloads out of the box.

fixes https://github.com/actions/setup-python/issues/512