### PR TITLE
Skip sqlite test for macOS python version 3.11 and higher

### DIFF
--- a/tests/python-tests.ps1
+++ b/tests/python-tests.ps1
@@ -56,7 +56,7 @@ Describe "Tests" {
     #     }
     # }
 
-    if (($Version -ge "3.2.0") -and -not ([semver]"$($Version.Major).$($Version.Minor)" -eq [semver]"3.11" -and $Version.PreReleaseLabel)) {
+    if (($Version -ge "3.2.0") -and ($Version -lt "3.11.0")) {
         It "Check if sqlite3 module is installed" {
             "python ./sources/python-sqlite3.py" | Should -ReturnZeroExitCode
         }


### PR DESCRIPTION
Test for `sqlite` doesn't work for official pre-build macOS python binaries. We use these pre-build binaries for python 3.11 and higher. Changed the condition for `sqlite3` test. This test still be used for builds from source code for previous python versions.

Test build: https://github.com/vsafonkin/python-versions/actions/runs/3327558757