### PR TITLE
Downgrade version of the github-script action

### DIFF
--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -182,7 +182,7 @@ jobs:
             Python ${{ env.VERSION }}
 
       - name: Upload release assets
-        uses: actions/github-script@v6
+        uses: actions/github-script@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -205,7 +205,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Trigger "Create Pull Request" workflow
-      uses: actions/github-script@v6
+      uses: actions/github-script@v3
       with:
         github-token: ${{ secrets.PERSONAL_TOKEN }}
         script: |


### PR DESCRIPTION
`github-script` action version was recently updated to `v6`. This version causes the error when building python packages:
```
Unhandled error: TypeError: Cannot read properties of undefined (reading 'uploadReleaseAsset')
```

We are going to temporarily downgrade the version and investigate the issue later on.