### PR TITLE
Update github-script action version

### DIFF
--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -182,7 +182,7 @@ jobs:
             Python ${{ env.VERSION }}
 
       - name: Upload release assets
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -190,7 +190,7 @@ jobs:
             for (let artifactDir of fs.readdirSync('.')) {
               let artifactName = fs.readdirSync(`${artifactDir}`)[0];
               console.log(`Upload ${artifactName} asset`);
-              github.repos.uploadReleaseAsset({
+              github.rest.repos.uploadReleaseAsset({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 release_id: ${{ steps.create_release.outputs.id }},
@@ -205,11 +205,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Trigger "Create Pull Request" workflow
-      uses: actions/github-script@v3
+      uses: actions/github-script@v6
       with:
         github-token: ${{ secrets.PERSONAL_TOKEN }}
         script: |
-          github.actions.createWorkflowDispatch({
+          github.rest.actions.createWorkflowDispatch({
             owner: context.repo.owner,
             repo: context.repo.repo,
             workflow_id: 'create-pr.yml',


### PR DESCRIPTION
Starting from `v5` github-script action release, the Octokit context available via `github` no longer has REST methods directly. These methods are available via `github.rest.*` ([release notes](https://github.com/actions/github-script#breaking-changes-in-v5)).

Changes were successfully tested. Here is a test [build](https://github.com/MaksimZhukov/python-versions/actions/runs/3427535704).