### PR TITLE
Remove asyncore and asynchat modules from tests

### DIFF
--- a/tests/sources/python-modules.py
+++ b/tests/sources/python-modules.py
@@ -271,9 +271,11 @@ if sys.version_info >= (3, 11) and platform.system() == 'Linux' and '18.04' in p
     standard_library.remove('tkinter')
     standard_library.remove('turtle')
 
-# 'smtpd' module has been removed from Python 3.12
+# 'smtpd', 'asyncore' and 'asynchat' modules have been removed from Python 3.12
 if sys.version_info >= (3, 12):
     standard_library.remove('smtpd')
+    standard_library.remove('asyncore')
+    standard_library.remove('asynchat')
 
 # Remove tkinter and Easter eggs
 excluded_modules = [


### PR DESCRIPTION
The 'asyncore' and 'asynchat' modules have been removed from Python 3.12 in scope of this [PR](https://github.com/python/cpython/issues/72719), so we need to remove them from tests accordingly. Please find details in the [3.12.0a2 changelog](https://docs.python.org/3.12/whatsnew/changelog.html#changelog).

Related issue: [4618](https://github.com/actions/runner-images-internal/issues/4618)