### PR TITLE
Switch Python generation from macOS 10.15 to 11

### DIFF
--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -14,7 +14,7 @@ on:
       PLATFORMS:
         description: 'Platforms for execution in "os" or "os_arch" format (arch is "x64" by default)'
         required: true
-        default: 'ubuntu-18.04,ubuntu-20.04,ubuntu-22.04,macos-10.15,windows-2019_x64,windows-2019_x86'
+        default: 'ubuntu-18.04,ubuntu-20.04,ubuntu-22.04,macos-11,windows-2019_x64,windows-2019_x86'
   pull_request:
     paths-ignore:
     - 'versions-manifest.json'
@@ -38,7 +38,7 @@ jobs:
       - name: Generate execution matrix
         id: generate-matrix
         run: |
-          $configurations = "${{ github.event.inputs.platforms || 'ubuntu-18.04,ubuntu-20.04,ubuntu-22.04,macos-10.15,windows-2019_x64,windows-2019_x86' }}".Split(",").Trim()
+          [String[]]$configurations = "${{ github.event.inputs.platforms || 'ubuntu-18.04,ubuntu-20.04,ubuntu-22.04,macos-11,windows-2019_x64,windows-2019_x86' }}".Split(",").Trim()
           $matrix = @()
 
           foreach ($configuration in $configurations) {
@@ -56,7 +56,7 @@ jobs:
               'arch' = $arch
             }
           }
-          echo "matrix=$($matrix | ConvertTo-Json -Compress)" >> $env:GITHUB_OUTPUT
+          echo "matrix=$($matrix | ConvertTo-Json -Compress -AsArray)" >> $env:GITHUB_OUTPUT
 
   build_python:
     needs: generate_matrix

--- a/installers/macos-pkg-setup-template.sh
+++ b/installers/macos-pkg-setup-template.sh
@@ -54,7 +54,13 @@ echo "Create additional symlinks (Required for the UsePythonVersion Azure Pipeli
 ln -s ./bin/$PYTHON_MAJOR_DOT_MINOR python
 
 cd bin/
-ln -s $PYTHON_MAJOR_DOT_MINOR $PYTHON_MAJOR_MINOR
+
+# This symlink already exists if Python version with the same major.minor version is already installed, 
+# since we do not remove the framework folder
+if [ ! -f $PYTHON_MAJOR_MINOR ]; then
+    ln -s $PYTHON_MAJOR_DOT_MINOR $PYTHON_MAJOR_MINOR
+fi
+
 if [ ! -f python ]; then
     ln -s $PYTHON_MAJOR_DOT_MINOR python
 fi

--- a/installers/macos-pkg-setup-template.sh
+++ b/installers/macos-pkg-setup-template.sh
@@ -55,7 +55,7 @@ ln -s ./bin/$PYTHON_MAJOR_DOT_MINOR python
 
 cd bin/
 
-# This symlink already exists if Python version with the same major.minor version is already installed, 
+# This symlink already exists if Python version with the same major.minor version is installed, 
 # since we do not remove the framework folder
 if [ ! -f $PYTHON_MAJOR_MINOR ]; then
     ln -s $PYTHON_MAJOR_DOT_MINOR $PYTHON_MAJOR_MINOR


### PR DESCRIPTION
The macOS 10.15 Actions runner image will be deprecated on 12/1/22 for GitHub and ADO. See related [announcement](https://github.com/actions/runner-images/issues/5583). In scope of this PR we switched Python generation from macOS 10.15 to 11.

Here is a list of successful test builds:
- [Python 3.12](https://github.com/MaksimZhukov/python-versions/actions/runs/3563659810)
- [Python 3.11](https://github.com/MaksimZhukov/python-versions/actions/runs/3563678359)
- [Python 3.10](https://github.com/MaksimZhukov/python-versions/actions/runs/3563681163)
- [Python 3.9](https://github.com/MaksimZhukov/python-versions/actions/runs/3563685256)
- [Python 3.8](https://github.com/MaksimZhukov/python-versions/actions/runs/3563692899)
- [Python 3.7](https://github.com/MaksimZhukov/python-versions/actions/runs/3563700014)

We also fixed 2 bugs:
1) Previously, we could not run builds with single OS as an input. It was fixed by passing an array of the generated matrix.
2) We do not remove the framework folder for `universal2` Python versions, so previously created symlinks are not removed as well. This leads to errors if we try to install a Python version with the same `major.minor` version. It was fixed by additional `if` statement.

**Related issue:** [4233](https://github.com/actions/runner-images-internal/issues/4233)