### PR TITLE
Update workflows to use reusable ones

### DIFF
--- a/.github/workflows/build-python-packages.yml
+++ b/.github/workflows/build-python-packages.yml
@@ -1,16 +1,17 @@
-name: Build python package
-
+name: Build Python package
+run-name: Generate Python ${{ inputs.VERSION || '3.11.0' }}
 on:
   workflow_dispatch:
     inputs:
       VERSION:
         description: 'Python version to build and upload'
-        default: '3.9.9'
+        default: '3.11.0'
         required: true
       PUBLISH_RELEASES:
         description: 'Whether to publish releases'
         required: true
-        default: 'false'
+        type: boolean
+        default: false
       PLATFORMS:
         description: 'Platforms for execution in "os" or "os_arch" format (arch is "x64" by default)'
         required: true
@@ -24,7 +25,7 @@ on:
     - 'main'
 
 env:
-  VERSION: ${{ github.event.inputs.VERSION || '3.9.9' }}
+  VERSION: ${{ inputs.VERSION || '3.11.0' }}
 defaults:
   run:
     shell: pwsh
@@ -66,7 +67,7 @@ jobs:
         include: ${{ fromJson(needs.generate_matrix.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     env:
-      ARTIFACT_NAME: python-${{ github.event.inputs.VERSION || '3.9.9' }}-${{ matrix.platform }}-${{ matrix.arch }}
+      ARTIFACT_NAME: python-${{ inputs.VERSION || '3.11.0' }}-${{ matrix.platform }}-${{ matrix.arch }}
     steps:
 
       - name: Check out repository code
@@ -93,7 +94,7 @@ jobs:
         include: ${{ fromJson(needs.generate_matrix.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     env:
-      ARTIFACT_NAME: python-${{ github.event.inputs.VERSION || '3.9.9' }}-${{ matrix.platform }}-${{ matrix.arch }}
+      ARTIFACT_NAME: python-${{ inputs.VERSION || '3.11.0' }}-${{ matrix.platform }}-${{ matrix.arch }}
     steps:
 
       - name: Check out repository code
@@ -207,7 +208,7 @@ jobs:
     - name: Trigger "Create Pull Request" workflow
       uses: actions/github-script@v6
       with:
-        github-token: ${{ secrets.PERSONAL_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           github.rest.actions.createWorkflowDispatch({
             owner: context.repo.owner,

--- a/.github/workflows/build-python-packages.yml
+++ b/.github/workflows/build-python-packages.yml
@@ -165,7 +165,7 @@ jobs:
 
   publish_release:
       name: Publish release
-      if: github.event_name == 'workflow_dispatch' && inputs.PUBLISH_RELEASES == 'true'
+      if: github.event_name == 'workflow_dispatch' && inputs.PUBLISH_RELEASES
       needs: test_python
       runs-on: ubuntu-latest
       steps:

--- a/.github/workflows/build-python-packages.yml
+++ b/.github/workflows/build-python-packages.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Generate execution matrix
         id: generate-matrix
         run: |
-          [String[]]$configurations = "${{ github.event.inputs.platforms || 'ubuntu-18.04,ubuntu-20.04,ubuntu-22.04,macos-11,windows-2019_x64,windows-2019_x86' }}".Split(",").Trim()
+          [String[]]$configurations = "${{ inputs.platforms || 'ubuntu-18.04,ubuntu-20.04,ubuntu-22.04,macos-11,windows-2019_x64,windows-2019_x86' }}".Split(",").Trim()
           $matrix = @()
 
           foreach ($configuration in $configurations) {
@@ -165,7 +165,7 @@ jobs:
 
   publish_release:
       name: Publish release
-      if: github.event_name == 'workflow_dispatch' && github.event.inputs.PUBLISH_RELEASES == 'true'
+      if: github.event_name == 'workflow_dispatch' && inputs.PUBLISH_RELEASES == 'true'
       needs: test_python
       runs-on: ubuntu-latest
       steps:

--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -2,32 +2,9 @@ name: Create Pull Request
 on:
   workflow_dispatch:
 
-defaults:
-  run:
-    shell: pwsh
-
 jobs:
-  create_pr:
-    name: Create Pull Request
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-
-    - name: Create versions-manifest.json
-      run: |
-        ./helpers/packages-generation/manifest-generator.ps1 -RepositoryFullName "$env:GITHUB_REPOSITORY" `
-                                                             -GitHubAccessToken "${{secrets.GITHUB_TOKEN}}" `
-                                                             -OutputFile "./versions-manifest.json" `
-                                                             -ConfigurationFile "./config/python-manifest-config.json"
-    - name: Create GitHub PR
-      run: |
-        $formattedDate = Get-Date -Format "MM/dd/yyyy"
-        ./helpers/github/create-pull-request.ps1 `
-                            -RepositoryFullName "$env:GITHUB_REPOSITORY" `
-                            -AccessToken "${{secrets.GITHUB_TOKEN}}" `
-                            -BranchName "update-versions-manifest-file" `
-                            -CommitMessage "Update versions-manifest" `
-                            -PullRequestTitle "[versions-manifest] Update for release from ${formattedDate}" `
-                            -PullRequestBody "Update versions-manifest.json for release from ${formattedDate}"
+  create-pr:
+    uses: actions/versions-package-tools/.github/workflows/create-pr-to-update-manifest.yml@main
+    with:
+      tool-name: "python"
+    secrets: inherit

--- a/.github/workflows/get-python-versions.yml
+++ b/.github/workflows/get-python-versions.yml
@@ -4,93 +4,10 @@ on:
     - cron: '0 3,15 * * *'
   workflow_dispatch:
 
-env:
-  TOOL_NAME: "Python"
-defaults:
-  run:
-    shell: pwsh
-
 jobs:
-  find_new_versions:
-    if: github.repository_owner == 'actions'
-    name: Find new versions
-    runs-on: ubuntu-latest
-    outputs:
-      versions_output: ${{ steps.Get_new_versions.outputs.TOOL_VERSIONS }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-
-      - id: Get_new_versions
-        name: Get new versions
-        run: ./helpers/get-new-tool-versions/get-new-tool-versions.ps1 -ToolName ${{ env.TOOL_NAME }}
-
-  check_new_versions:
-    name: Check new versions
-    runs-on: ubuntu-latest
-    needs: find_new_versions
-    env:
-      TOOL_VERSIONS: ${{needs.find_new_versions.outputs.versions_output}}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-
-      - name: Check Versions
-        if: env.TOOL_VERSIONS == ''
-        run: |
-          Write-Host "No new versions were found"
-          Import-Module "./helpers/github/github-api.psm1"
-          $gitHubApi = Get-GitHubApi -RepositoryFullName "$env:GITHUB_REPOSITORY" `
-                                     -AccessToken "${{ secrets.PERSONAL_TOKEN }}"
-          $gitHubApi.CancelWorkflow("$env:GITHUB_RUN_ID")
-          Start-Sleep -Seconds 60
-      - name: Send Slack notification
-        run: |
-          $pipelineUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
-          $message = "The following versions of '${{ env.TOOL_NAME }}' are available to upload: ${{ env.TOOL_VERSIONS }}\nLink to the pipeline: $pipelineUrl"
-          ./helpers/get-new-tool-versions/send-slack-notification.ps1 -Url "${{ secrets.SLACK_CHANNEL_URL }}" `
-                                                                      -ToolName "${{ env.TOOL_NAME }}" `
-                                                                      -ImageUrl "https://avatars.githubusercontent.com/u/1525981?s=200&v=4" `
-                                                                      -Text "$message"
-  
-  trigger_builds:
-    name: Trigger builds
-    runs-on: ubuntu-latest
-    needs: [find_new_versions, check_new_versions]
-    env:
-      TOOL_VERSIONS: ${{needs.find_new_versions.outputs.versions_output}}
-    environment: Get Available Tools Versions - Publishing Approval
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-
-      - name: Trigger "Build python packages" workflow
-        run:
-          ./helpers/github/run-ci-builds.ps1 -RepositoryFullName "$env:GITHUB_REPOSITORY" `
-                                             -AccessToken "${{ secrets.PERSONAL_TOKEN }}" `
-                                             -WorkflowFileName "python-builder.yml" `
-                                             -WorkflowDispatchRef "main" `
-                                             -ToolVersions "${{ env.TOOL_VERSIONS }}" `
-                                             -PublishReleases "true"
-
-  check_build:
-    name: Check build for failures 
-    runs-on: ubuntu-latest
-    needs: [find_new_versions, check_new_versions, trigger_builds]
-    if: failure()
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-
-      - name: Send Slack notification if build fails
-        run: |
-          $pipelineUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
-          $message = "The build of the '${{ env.TOOL_NAME }}' detection pipeline failed :progress-error:\nLink to the pipeline: $pipelineUrl"
-          ./helpers/get-new-tool-versions/send-slack-notification.ps1 -Url "${{ secrets.SLACK_CHANNEL_URL }}" `
-                                                                      -ToolName "${{ env.TOOL_NAME }}" `
-                                                                      -Text "$message" `
-                                                                      -ImageUrl "https://avatars.githubusercontent.com/u/1525981?s=200&v=4"
+  get-new-python-versions:
+    uses: actions/versions-package-tools/.github/workflows/get-new-tool-versions.yml@main
+    with:
+      tool-name: "Python"
+      image-url: "https://avatars.githubusercontent.com/u/1525981?s=200&v=4"
+    secrets: inherit

--- a/.github/workflows/python-versions-runner.yml
+++ b/.github/workflows/python-versions-runner.yml
@@ -28,4 +28,4 @@ jobs:
           $versions = ${{ github.event.inputs.versions }}
           ./builders/python-versions-runner.ps1 -Versions $versions.Split(",") -PublishRelease ${{ github.event.inputs.publish-releases }}
         env:
-          PERSONAL_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-manifest.yml
+++ b/.github/workflows/validate-manifest.yml
@@ -1,6 +1,8 @@
 name: Validate manifest
-
 on:
+# The GITHUB_TOKEN secret is used to create a PR
+# The pull_request event will not be triggered by it
+# That's one of the reasons we need the schedule to validate the versions-manifest.json file
   schedule:
     - cron: '0 8,20 * * *'
 
@@ -10,40 +12,10 @@ on:
     paths:
       - 'versions-manifest.json'
 
-env:
-  TOOL_NAME: "Python"
-
-defaults:
-  run:
-    shell: pwsh
-
 jobs:
-  validation:
-    if: github.repository_owner == 'actions'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-
-      - name: Validate python-versions manifest
-        run: .\helpers\packages-generation\manifest-validator.ps1 -ManifestPath '.\versions-manifest.json'
-
-  check_build:
-    name: Check validation for failures 
-    runs-on: ubuntu-latest
-    needs: [validation]
-    if: failure()
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-
-      - name: Send Slack notification if validation fails
-        run: |
-          $pipelineUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
-          $message = "The validation of python-versions manifest failed. \nLink to the pipeline: $pipelineUrl"
-          .\helpers\get-new-tool-versions\send-slack-notification.ps1 -Url "${{ secrets.SLACK_CHANNEL_URL }}" `
-                                                                      -ToolName "${{ env.TOOL_NAME }}" `
-                                                                      -Text "$message" `
-                                                                      -ImageUrl "https://www.python.org/static/community_logos/python-powered-h-100x130.png"
+  manifest:
+    uses: actions/versions-package-tools/.github/workflows/validate-manifest.yml@main
+    with:
+      tool-name: "Python"
+      image-url: "https://avatars.githubusercontent.com/u/1525981?s=200&v=4"
+    secrets: inherit

--- a/.github/workflows/validate-manifest.yml
+++ b/.github/workflows/validate-manifest.yml
@@ -5,7 +5,7 @@ on:
 # That's one of the reasons we need the schedule to validate the versions-manifest.json file
   schedule:
     - cron: '0 8,20 * * *'
-
+  workflow_dispatch:
   pull_request:
     branches:
       - main

--- a/builders/invoke-workflow.psm1
+++ b/builders/invoke-workflow.psm1
@@ -12,10 +12,10 @@ function Invoke-Workflow {
         }
     } | ConvertTo-Json
     $headers = @{
-        Authorization="Bearer $env:PERSONAL_TOKEN"
+        Authorization="Bearer $env:TOKEN"
     }
     $actionsRepoUri = "$env:GITHUB_API_URL/repos/$env:GITHUB_REPOSITORY/actions"
-    Invoke-RestMethod -uri "$actionsRepoUri/workflows/python-builder.yml/dispatches" -method POST -headers $headers -body $payload
+    Invoke-RestMethod -uri "$actionsRepoUri/workflows/build-python-packages.yml/dispatches" -method POST -headers $headers -body $payload
 
     $result = [PSCustomObject]@{
         Version = $Version


### PR DESCRIPTION
In scope of this PR, we updated existing workflows to use reusable ones. 

Notes:
1) We replaced the `PERSONAL_TOKEN` with the `GITHUB_TOKEN`. Now, it is possible to use the `GITHUB_TOKEN` with `workflow_dispatch` event to trigger workflows (see details [here](https://github.blog/changelog/2022-09-08-github-actions-use-github_token-with-workflow_dispatch-and-repository_dispatch/)).
2) Also we added the `run-name` to display the Python version in the workflow run name. Now it's much easier to find the right build
![image](https://user-images.githubusercontent.com/46996400/205879963-98b1595d-8b62-469b-91d4-1a037576bf33.png)

**Related issue:**  [4596](https://github.com/actions/runner-images-internal/issues/4596)