### PR TITLE
Remove tests for deprecated libraries

### DIFF
--- a/tests/sources/python-config-output.py
+++ b/tests/sources/python-config-output.py
@@ -1,6 +1,4 @@
-import distutils.sysconfig
 import sysconfig
 
 from pprint import pprint
 pprint(sysconfig.get_config_vars())
-pprint(distutils.sysconfig.get_config_vars())

--- a/tests/sources/python-config-test.py
+++ b/tests/sources/python-config-test.py
@@ -1,5 +1,3 @@
-import distutils.sysconfig
-from distutils.version import LooseVersion
 import sysconfig
 import sys
 import platform
@@ -54,6 +52,8 @@ else:
 
 ### Validate macOS
 if os_type == 'Darwin':
+    if version_major == 3 and version_minor < 12:
+        from distutils.version import LooseVersion
     ### Validate openssl links
     if LooseVersion(nativeVersion) < LooseVersion("3.7.0"):
         expected_ldflags = '-L/usr/local/opt/openssl@1.1/lib'

--- a/tests/sources/python-config-test.py
+++ b/tests/sources/python-config-test.py
@@ -52,10 +52,8 @@ else:
 
 ### Validate macOS
 if os_type == 'Darwin':
-    if version_major == 3 and version_minor < 12:
-        from distutils.version import LooseVersion
     ### Validate openssl links
-    if LooseVersion(nativeVersion) < LooseVersion("3.7.0"):
+    if version_major == 3 and version_minor < 7:
         expected_ldflags = '-L/usr/local/opt/openssl@1.1/lib'
         ldflags = sysconfig.get_config_var('LDFLAGS')
 

--- a/tests/sources/python-modules.py
+++ b/tests/sources/python-modules.py
@@ -267,6 +267,7 @@ if sys.version_info >= (3, 11):
 
 # 'smtpd', 'asyncore' and 'asynchat' modules have been removed from Python 3.12
 if sys.version_info >= (3, 12):
+    standard_library.remove('distutils')
     standard_library.remove('smtpd')
     standard_library.remove('asyncore')
     standard_library.remove('asynchat')

--- a/tests/sources/python-modules.py
+++ b/tests/sources/python-modules.py
@@ -266,8 +266,10 @@ if sys.version_info >= (3, 11):
     standard_library.remove('binhex')
 
 # 'smtpd', 'asyncore' and 'asynchat' modules have been removed from Python 3.12
+# https://docs.python.org/dev/whatsnew/3.12.html
 if sys.version_info >= (3, 12):
     standard_library.remove('distutils')
+    standard_library.remove('imp')
     standard_library.remove('smtpd')
     standard_library.remove('asyncore')
     standard_library.remove('asynchat')


### PR DESCRIPTION
In scope of this pull request we remove tests for deprecated libraries. 
 - distutils, imp: https://docs.python.org/dev/whatsnew/3.12.html