### PR TITLE
Adding ARM64 support for Ubuntu to resolve encountered issue on actions/setup-python

### DIFF
--- a/.github/workflows/build-python-packages.yml
+++ b/.github/workflows/build-python-packages.yml
@@ -15,7 +15,7 @@ on:
       PLATFORMS:
         description: 'Platforms for execution in "os" or "os_arch" format (arch is "x64" by default)'
         required: true
-        default: 'ubuntu-20.04,ubuntu-22.04,macos-11_x64,macos-11_arm64,windows-2019_x64,windows-2019_x86'
+        default: 'ubuntu-20.04,ubuntu-20.04_arm64,ubuntu-22.04,ubuntu-22.04_arm64,macos-11_x64,macos-11_arm64,windows-2019_x64,windows-2019_x86'
   pull_request:
     paths-ignore:
     - 'versions-manifest.json'
@@ -39,7 +39,7 @@ jobs:
       - name: Generate execution matrix
         id: generate-matrix
         run: |
-          [String[]]$configurations = "${{ inputs.platforms || 'ubuntu-20.04,ubuntu-22.04,macos-11,macos-11_arm64,windows-2019_x64,windows-2019_x86' }}".Split(",").Trim()
+          [String[]]$configurations = "${{ inputs.platforms || 'ubuntu-20.04,ubuntu-20.04_arm64,ubuntu-22.04,ubuntu-22.04_arm64,macos-11,macos-11_arm64,windows-2019_x64,windows-2019_x86' }}".Split(",").Trim()
           $matrix = @()
 
           foreach ($configuration in $configurations) {


### PR DESCRIPTION
Hey,

I have created a pull request (PR) to address an issue I encountered on Ubuntu related to the ARM64 architecture. The issue details can be found here: python/issues/678#issuecomment-1564392289.

In this PR, I have added support for ARM64 in the build step, aiming to fix the problem. However, due to the usage of the repository's registry in the test phase, I'm unable to validate the change at the moment.

I kindly request your review and consideration of this PR. I would greatly appreciate any feedback or guidance you can provide on how to validate the effectiveness of this modification.

Thank you for your time and attention. I look forward to working with you to resolve this issue and improve compatibility for Ubuntu users on ARM64.

Best regards,
Joeri






