### PR TITLE
Matching Python Version for 3.11 with Manifest to Prevent Pipeline Failures

### DIFF
--- a/.github/workflows/releases-validation.yml
+++ b/.github/workflows/releases-validation.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
-        python: [3.9.12, 3.10.8, 3.11.10]
+        python: [3.9.12, 3.10.8, 3.11.3]
     steps:
     - name: setup-python ${{ matrix.python }}
       uses: actions/setup-python@v4


### PR DESCRIPTION
Hey,

I am submitting a pull request (PR) to address an issue related to the Python version mismatch in the manifest file, which causes pipeline failures. 

The current state of the project's manifest file specifies a different Python version for 3.11 than what is being used in the pipelines. This discrepancy results in failures during pipeline execution. To rectify this issue, my proposed PR ensures that the Python version used for 3.11 aligns with the one specified in the manifest file.

Best regards,
Joeri