### PR TITLE
Use `--upgrade` instead of `--ignore-installed` to upgrade `pip`.

### DIFF
--- a/installers/nix-setup-template.sh
+++ b/installers/nix-setup-template.sh
@@ -50,7 +50,7 @@ chmod +x ../python $PYTHON_MAJOR $PYTHON_MAJOR_DOT_MINOR $PYTHON_MAJORMINOR pyth
 
 echo "Upgrading pip..."
 ./python -m ensurepip
-./python -m pip install --ignore-installed pip --disable-pip-version-check --no-warn-script-location --root-user-action=ignore
+./python -m pip install --upgrade pip --disable-pip-version-check --no-warn-script-location --root-user-action=ignore
 
 echo "Create complete file"
 touch $PYTHON_TOOLCACHE_VERSION_PATH/x64.complete


### PR DESCRIPTION
This PR fixes the following issues:
* https://github.com/actions/setup-python/issues/785
* https://github.com/actions/setup-python/issues/713

I tried running both commands in a test venv.

Using `--ignore-installed` leaves behind `pip-23.2.dist-info`:
```console
$ python3 -m && source venv/bin/activate
$ ls venv/lib64/python3.11/site-packages/ | grep pip
pip
pip-23.2.dist-info
$ python -m pip install --ignore-installed pip --disable-pip-version-check --no-warn-script-location --root-user-action=ignore
Collecting pip
  Obtaining dependency information for pip from https://files.pythonhosted.org/packages/15/aa/3f4c7bcee2057a76562a5b33ecbd199be08cdb4443a02e26bd2c3cf6fc39/pip-23.3.2-py3-none-any.whl.metadata
  Using cached pip-23.3.2-py3-none-any.whl.metadata (3.5 kB)
Using cached pip-23.3.2-py3-none-any.whl (2.1 MB)
Installing collected packages: pip
Successfully installed pip-23.3.2
$ ls venv/lib64/python3.11/site-packages/ | grep pip
pip
pip-23.2.dist-info
pip-23.3.2.dist-info
$ deactivate && rm -rf venv
```

Using `--upgrade` instead of `--ignore-installed` removes the old version (see the `Attempting uninstall: pip` part in the output), upgrades `pip` from `23.2` to `23.3.2`, and doesn't leave `pip-23.2.dist-info` behind:
```console
$ python3 -m && source venv/bin/activate
$ ls venv/lib64/python3.11/site-packages/ | grep pip
pip
pip-23.2.dist-info
$ python -m pip install --upgrade pip --disable-pip-version-check --no-warn-script-location --root-user-action=ignore
Requirement already satisfied: pip in ./venv/lib/python3.11/site-packages (23.2)
Collecting pip
  Obtaining dependency information for pip from https://files.pythonhosted.org/packages/15/aa/3f4c7bcee2057a76562a5b33ecbd199be08cdb4443a02e26bd2c3cf6fc39/pip-23.3.2-py3-none-any.whl.metadata
  Using cached pip-23.3.2-py3-none-any.whl.metadata (3.5 kB)
Using cached pip-23.3.2-py3-none-any.whl (2.1 MB)
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 23.2
    Uninstalling pip-23.2:
      Successfully uninstalled pip-23.2
Successfully installed pip-23.3.2
$ ls venv/lib64/python3.11/site-packages/ | grep pip
pip
pip-23.3.2.dist-info
```
Note that:
* just removing `--ignore-installed` is not enough, since no upgrade takes place unless `--upgrade` is also added
* the `--ignore-installed` has been there since the beginning (c641695f6a07526c18f10e374e503e649fef9427)
* I'm not 100% sure this will fix the linked issue, nor I'm sure how to verify/test that