### PR TITLE
fix: use environment variable for `PIP_ROOT_USER_ACTION`

### DIFF
--- a/installers/macos-pkg-setup-template.sh
+++ b/installers/macos-pkg-setup-template.sh
@@ -69,8 +69,9 @@ fi
 chmod +x ../python $PYTHON_MAJOR $PYTHON_MAJOR_DOT_MINOR $PYTHON_MAJOR_MINOR python
 
 echo "Upgrading pip..."
+export PIP_ROOT_USER_ACTION=ignore
 ./python -m ensurepip
-./python -m pip install --ignore-installed pip --disable-pip-version-check --no-warn-script-location --root-user-action=ignore
+./python -m pip install --ignore-installed pip --disable-pip-version-check --no-warn-script-location
 
 echo "Install OpenSSL certificates"
 sh -e "${PYTHON_APPLICATION_PATH}/Install Certificates.command"


### PR DESCRIPTION
The option does not exists in every pip version, using the environment variable allows for pip not to fail in this case.
This is required to build macOS arm64 packages of python 3.8 & 3.9 as requested in https://github.com/actions/setup-python/issues/808

builds can be seen in https://github.com/mayeut/python-versions/actions/workflows/build-python-packages.yml