### PR TITLE
fix: use environment variable for `PIP_ROOT_USER_ACTION`

### DIFF
--- a/.github/workflows/build-python-packages.yml
+++ b/.github/workflows/build-python-packages.yml
@@ -123,6 +123,7 @@ jobs:
 
       - name: Apply build artifact to the local machine
         run: |
+          $PSNativeCommandUseErrorActionPreference = $true
           if ('${{ matrix.platform }}' -eq 'win32') {
             powershell ./setup.ps1
             } else {

--- a/installers/nix-setup-template.sh
+++ b/installers/nix-setup-template.sh
@@ -49,8 +49,9 @@ fi
 chmod +x ../python $PYTHON_MAJOR $PYTHON_MAJOR_DOT_MINOR $PYTHON_MAJORMINOR python
 
 echo "Upgrading pip..."
+export PIP_ROOT_USER_ACTION=ignore
 ./python -m ensurepip
-./python -m pip install --ignore-installed pip --disable-pip-version-check --no-warn-script-location --root-user-action=ignore
+./python -m pip install --ignore-installed pip --disable-pip-version-check --no-warn-script-location
 
 echo "Create complete file"
 touch $PYTHON_TOOLCACHE_VERSION_PATH/x64.complete

--- a/installers/win-setup-template.ps1
+++ b/installers/win-setup-template.ps1
@@ -133,8 +133,9 @@ if ($MajorVersion -ne "2") {
 }
 
 Write-Host "Install and upgrade Pip"
+$Env:PIP_ROOT_USER_ACTION = "ignore"
 $PythonExePath = Join-Path -Path $PythonArchPath -ChildPath "python.exe"
-cmd.exe /c "$PythonExePath -m ensurepip && $PythonExePath -m pip install --upgrade pip --no-warn-script-location --root-user-action=ignore"
+cmd.exe /c "$PythonExePath -m ensurepip && $PythonExePath -m pip install --upgrade pip --no-warn-script-location"
 if ($LASTEXITCODE -ne 0) {
     Throw "Error happened during pip installation / upgrade"
 }

--- a/installers/win-setup-template.ps1
+++ b/installers/win-setup-template.ps1
@@ -135,6 +135,9 @@ if ($MajorVersion -ne "2") {
 Write-Host "Install and upgrade Pip"
 $PythonExePath = Join-Path -Path $PythonArchPath -ChildPath "python.exe"
 cmd.exe /c "$PythonExePath -m ensurepip && $PythonExePath -m pip install --upgrade pip --no-warn-script-location --root-user-action=ignore"
+if ($LASTEXITCODE -ne 0) {
+    Throw "Error happened during pip installation / upgrade"
+}
 
 Write-Host "Create complete file"
 New-Item -ItemType File -Path $PythonVersionPath -Name "$Architecture.complete" | Out-Null


### PR DESCRIPTION
This extends the fix from https://github.com/actions/python-versions/pull/259 since every platform for 3.8.10 / 3.9.13 has been rebuilt instead of just macOS arm64 being added.

This also fixes the build workflow to error out on installation failure which should have prevented the broken build to be published:
- commit b4dd4cdda390f2a1ddc17291932438b0a29d0054
- c.f. build https://github.com/mayeut/python-versions/actions/runs/8852915857

Since the Windows version was not erroring out properly, I also added a check for pip installation / update failure:
- commit d05150c17299218791deff36b55d00483efd12a5
- c.f. build https://github.com/mayeut/python-versions/actions/runs/8853154242

Now that everything errors out properly, we can check that the fix works in https://github.com/mayeut/python-versions/actions/runs/8853283598

Towards fixing https://github.com/actions/setup-python/issues/853