### PR TITLE
fix: use `--upgrade` rather than `--ignore-installed` to upgrade pip

### DIFF
--- a/.github/workflows/build-python-packages.yml
+++ b/.github/workflows/build-python-packages.yml
@@ -105,6 +105,11 @@ jobs:
       - name: Fully cleanup the toolcache directory before testing
         run: ./helpers/clean-toolcache.ps1 -ToolName "Python"
 
+      - name: Delete macOS /Library/Frameworks/Python.framework
+        if: matrix.platform == 'darwin'
+        shell: bash
+        run: if [ -d /Library/Frameworks/Python.framework ]; then sudo rm -rf /Library/Frameworks/Python.framework; fi
+
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:

--- a/installers/macos-pkg-setup-template.sh
+++ b/installers/macos-pkg-setup-template.sh
@@ -71,7 +71,7 @@ chmod +x ../python $PYTHON_MAJOR $PYTHON_MAJOR_DOT_MINOR $PYTHON_MAJOR_MINOR pyt
 echo "Upgrading pip..."
 export PIP_ROOT_USER_ACTION=ignore
 ./python -m ensurepip
-./python -m pip install --ignore-installed pip --disable-pip-version-check --no-warn-script-location
+./python -m pip install --upgrade pip --disable-pip-version-check --no-warn-script-location
 
 echo "Install OpenSSL certificates"
 sh -e "${PYTHON_APPLICATION_PATH}/Install Certificates.command"

--- a/installers/nix-setup-template.sh
+++ b/installers/nix-setup-template.sh
@@ -51,7 +51,7 @@ chmod +x ../python $PYTHON_MAJOR $PYTHON_MAJOR_DOT_MINOR $PYTHON_MAJORMINOR pyth
 echo "Upgrading pip..."
 export PIP_ROOT_USER_ACTION=ignore
 ./python -m ensurepip
-./python -m pip install --ignore-installed pip --disable-pip-version-check --no-warn-script-location
+./python -m pip install --upgrade pip --disable-pip-version-check --no-warn-script-location
 
 echo "Create complete file"
 touch $PYTHON_TOOLCACHE_VERSION_PATH/x64.complete

--- a/tests/python-tests.ps1
+++ b/tests/python-tests.ps1
@@ -103,4 +103,8 @@ Describe "Tests" {
     It "Check urlopen with HTTPS works" {
         "python ./sources/python-urlopen-https.py" | Should -ReturnZeroExitCode
     }
+
+    It "Check a single dist-info per distribution is present" {
+        "python ./sources/dist-info.py" | Should -ReturnZeroExitCode
+    }
 }

--- a/tests/sources/dist-info.py
+++ b/tests/sources/dist-info.py
@@ -1,0 +1,24 @@
+import glob
+import os.path
+import sysconfig
+from collections import defaultdict
+
+
+def check_dist_info():
+    paths = set([sysconfig.get_path("purelib"), sysconfig.get_path("platlib")])
+    versions = defaultdict(list)
+    for path in paths:
+        pattern = os.path.join(path, "*.dist-info")
+        for dist_info in glob.glob(pattern):
+            name = os.path.basename(dist_info).split("-", maxsplit=1)[0]
+            versions[name].append(dist_info)
+    exit_code = 0
+    for name in versions:
+        if len(versions[name]) > 1:
+            print("multiple dist-info found for {}: {}".format(name, versions[name]))
+            exit_code = 1
+    exit(exit_code)
+
+
+if __name__ == "__main__":
+    check_dist_info()


### PR DESCRIPTION
This removes left over files when upgrading pip.

See #254 for more information on the issues fixed by this PR:
- https://github.com/actions/setup-python/issues/785
- https://github.com/actions/setup-python/issues/713

Extends #254 by adding a test & fixing `installers/macos-pkg-setup-template.sh`

Closes #254