### PR TITLE
fix: always reinstall pip

### DIFF
--- a/.github/workflows/build-python-packages.yml
+++ b/.github/workflows/build-python-packages.yml
@@ -1,11 +1,11 @@
 name: Build Python package
-run-name: Generate Python ${{ inputs.VERSION || '3.11.0' }}
+run-name: Generate Python ${{ inputs.VERSION || '3.12.3' }}
 on:
   workflow_dispatch:
     inputs:
       VERSION:
         description: 'Python version to build and upload'
-        default: '3.11.0'
+        default: '3.12.3'
         required: true
       PUBLISH_RELEASES:
         description: 'Whether to publish releases'
@@ -25,7 +25,7 @@ on:
     - 'main'
 
 env:
-  VERSION: ${{ inputs.VERSION || '3.11.0' }}
+  VERSION: ${{ inputs.VERSION || '3.12.3' }}
 defaults:
   run:
     shell: pwsh
@@ -67,7 +67,7 @@ jobs:
         include: ${{ fromJson(needs.generate_matrix.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     env:
-      ARTIFACT_NAME: python-${{ inputs.VERSION || '3.11.0' }}-${{ matrix.platform }}-${{ matrix.arch }}
+      ARTIFACT_NAME: python-${{ inputs.VERSION || '3.12.3' }}-${{ matrix.platform }}-${{ matrix.arch }}
     steps:
 
       - name: Check out repository code
@@ -94,7 +94,7 @@ jobs:
         include: ${{ fromJson(needs.generate_matrix.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     env:
-      ARTIFACT_NAME: python-${{ inputs.VERSION || '3.11.0' }}-${{ matrix.platform }}-${{ matrix.arch }}
+      ARTIFACT_NAME: python-${{ inputs.VERSION || '3.12.3' }}-${{ matrix.platform }}-${{ matrix.arch }}
     steps:
 
       - name: Check out repository code

--- a/installers/macos-pkg-setup-template.sh
+++ b/installers/macos-pkg-setup-template.sh
@@ -71,7 +71,7 @@ chmod +x ../python $PYTHON_MAJOR $PYTHON_MAJOR_DOT_MINOR $PYTHON_MAJOR_MINOR pyt
 echo "Upgrading pip..."
 export PIP_ROOT_USER_ACTION=ignore
 ./python -m ensurepip
-./python -m pip install --upgrade pip --disable-pip-version-check --no-warn-script-location
+./python -m pip install --upgrade --force-reinstall pip --disable-pip-version-check --no-warn-script-location
 
 echo "Install OpenSSL certificates"
 sh -e "${PYTHON_APPLICATION_PATH}/Install Certificates.command"

--- a/installers/nix-setup-template.sh
+++ b/installers/nix-setup-template.sh
@@ -51,7 +51,7 @@ chmod +x ../python $PYTHON_MAJOR $PYTHON_MAJOR_DOT_MINOR $PYTHON_MAJORMINOR pyth
 echo "Upgrading pip..."
 export PIP_ROOT_USER_ACTION=ignore
 ./python -m ensurepip
-./python -m pip install --upgrade pip --disable-pip-version-check --no-warn-script-location
+./python -m pip install --upgrade --force-reinstall pip --disable-pip-version-check --no-warn-script-location
 
 echo "Create complete file"
 touch $PYTHON_TOOLCACHE_VERSION_PATH/x64.complete

--- a/installers/win-setup-template.ps1
+++ b/installers/win-setup-template.ps1
@@ -135,7 +135,7 @@ if ($MajorVersion -ne "2") {
 Write-Host "Install and upgrade Pip"
 $Env:PIP_ROOT_USER_ACTION = "ignore"
 $PythonExePath = Join-Path -Path $PythonArchPath -ChildPath "python.exe"
-cmd.exe /c "$PythonExePath -m ensurepip && $PythonExePath -m pip install --upgrade pip --no-warn-script-location"
+cmd.exe /c "$PythonExePath -m ensurepip && $PythonExePath -m pip install --upgrade --force-reinstall pip --no-warn-script-location"
 if ($LASTEXITCODE -ne 0) {
     Throw "Error happened during pip installation / upgrade"
 }


### PR DESCRIPTION
If the default pip version is also the latest one, then the `pip` executable will be missing as the default pip is installed only as `pip3`/`pip3.x`.

In order to always provide a `pip` executable, always reinstall pip.

This also changes the default built version to 3.12.3 in the build workflow.

@HarithaVattikuti, this shall fix the issues you're seeing on the manual builds.