### PR TITLE
Don't try to continue for windows if download link for exe/msi doesn't exists for python version requested

### DIFF
--- a/builders/win-python-builder.psm1
+++ b/builders/win-python-builder.psm1
@@ -82,6 +82,28 @@ class WinPythonBuilder : PythonBuilder {
         return $uri
     }
 
+    [bool] PkgExists() {
+        <#
+        .SYNOPSIS
+        Checks if the Universal Pkg Uri actually exists.
+        #>
+        $pkgUri = $this.GetSourceUri()
+
+        try {
+            $statusCode = (Invoke-WebRequest -Uri $pkgUri -UseBasicParsing -DisableKeepAlive -Method head).StatusCode
+            if ($statusCode -eq 200) {
+                return $true
+            } else {
+                Write-Host "File at $pkgUri did not appear to be valid, with status code '$statusCode'"
+                return $false;
+            }
+        } catch {
+            $statusCode = [int]$_.Exception.Response.StatusCode
+            Write-Host "File at $pkgUri did not appear to be valid, with status code '$statusCode'"
+            return $false
+        }
+    }
+
     [string] Download() {
         <#
         .SYNOPSIS
@@ -131,13 +153,17 @@ class WinPythonBuilder : PythonBuilder {
         Generates Python artifact from downloaded Python installation executable.
         #>
 
-        Write-Host "Download Python $($this.Version) [$($this.Architecture)] executable..."
-        $this.Download()
+        if ($this.PkgExists()) {
+            Write-Host "Download Python $($this.Version) [$($this.Architecture)] executable..."
+            $this.Download()
 
-        Write-Host "Create installation script..."
-        $this.CreateInstallationScript()
+            Write-Host "Create installation script..."
+            $this.CreateInstallationScript()
 
-        Write-Host "Archive artifact"
-        $this.ArchiveArtifact()
+            Write-Host "Archive artifact"
+            $this.ArchiveArtifact()
+        } else {
+            Write-Host "No source URI can be found"
+        }
     }
 }


### PR DESCRIPTION
Only some minor versions of python have an actual windows .exe / .msi installer.

eg:

* this does https://www.python.org/downloads/release/python-3810/
* this doesn't https://www.python.org/downloads/release/python-3811/