### PR TITLE
Fix for Authenticode issuer mismatch problem on windows 2019

### DIFF
--- a/.github/workflows/build-python-packages.yml
+++ b/.github/workflows/build-python-packages.yml
@@ -158,7 +158,6 @@ jobs:
 
       - name: Run tests
         run: |
-            Install-Module Pester -Force -Scope CurrentUser
             Import-Module Pester
             $pesterContainer = New-PesterContainer -Path './python-tests.ps1' -Data @{
                 Version="${{ env.VERSION }}";


### PR DESCRIPTION
Fix for error related to the PowerShell Install-Package command happened in this [run](https://github.com/actions/python-versions/actions/runs/9390826268/job/25861941770).<br/>
<img width="1040" alt="Screenshot 2024-06-07 at 8 21 55 PM" src="https://github.com/actions/python-versions/assets/147705955/6ee10eeb-7b0d-4a86-9dd2-e1f880fddccb">
