### PR TITLE
fix: release assets upload

### DIFF
--- a/.github/workflows/build-python-packages.yml
+++ b/.github/workflows/build-python-packages.yml
@@ -212,16 +212,18 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
-            for (let artifactDir of fs.readdirSync('.')) {
-              let artifactName = fs.lstatSync(artifactDir).isDirectory() ? fs.readdirSync(`${artifactDir}`)[0] : artifactDir;
-  
+            const assert = require('assert');
+            for (let artifactName of fs.readdirSync('.')) {
+              assert(fs.lstatSync(artifactName).isFile());
               console.log(`Upload ${artifactName} asset`);
+              const isHashes = artifactName === 'hashes.sha256';
+              const data = fs.readFileSync(artifactName);
               github.rest.repos.uploadReleaseAsset({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 release_id: ${{ steps.create_release.outputs.id }},
                 name: artifactName,
-                data: fs.lstatSync(artifactDir).isDirectory() ? fs.readFileSync(`./${artifactDir}/${artifactName}`) : fs.readFileSync(`./${artifactName}`).toString()
+                data: isHashes ? data.toString() : data
               });
             }
 


### PR DESCRIPTION
actions/python-versions#267 introduced a regression in asset upload.

The layout of the artefacts to upload has changed. They're now all flatten in the working directory whereas before that PR, only the `hashes.sha256` file was directly in the working directory. The change in layout caused `.toString()` to be called on python archives which corrupts the data that gets uploaded (as can be seen by comparing sha256 in `hashes.sha256` with the ones from other uploaded assets).

This commit ensures that a "flat layout" is used and that `toString()` is only called for `hashes.sha256`.