### PR TITLE
Add Python debug build support

### DIFF
--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -31,10 +31,10 @@ class macOSPythonBuilder : NixPythonBuilder {
         .SYNOPSIS
         Prepare system environment by installing dependencies and required packages.
         #>
-        
+
         if ($this.Version -eq "3.7.17") {
-            # We have preinstalled ncurses and readLine on the hoster runners. But we need to install bzip2 for 
-            # setting up an environemnt 
+            # We have preinstalled ncurses and readLine on the hoster runners. But we need to install bzip2 for
+            # setting up an environemnt
             # If we get any issues realted to ncurses or readline we can try to run this command
             # brew install ncurses readline
             Execute-Command -Command "brew install bzip2"
@@ -53,6 +53,9 @@ class macOSPythonBuilder : NixPythonBuilder {
         $configureString += " --enable-optimizations"
         $configureString += " --enable-shared"
         $configureString += " --with-lto"
+        if ($this.WithPyDebug) {
+            $configureString += " --with-pydebug"
+        }
 
         ### For Python versions which support it, compile a universal2 (arm64 + x86_64 hybrid) build. The arm64 slice
         ### will never be used itself by a Github Actions runner but using a universal2 Python is the only way to build

--- a/builders/python-builder.psm1
+++ b/builders/python-builder.psm1
@@ -12,6 +12,9 @@ class PythonBuilder {
     .PARAMETER Architecture
     The architecture with which Python should be built.
 
+    .PARAMETER WithPyDebug
+    The flag that indicates whether Python should be a debug build with the --with-pydebug configure option.
+
     .PARAMETER HostedToolcacheLocation
     The location of hostedtoolcache artifacts. Using system AGENT_TOOLSDIRECTORY variable value.
 
@@ -97,9 +100,9 @@ class PythonBuilder {
     [void] PreparePythonToolcacheLocation() {
         <#
         .SYNOPSIS
-        Prepare system hostedtoolcache folder for new Python version. 
+        Prepare system hostedtoolcache folder for new Python version.
         #>
-        
+
         $pythonBinariesLocation = $this.GetFullPythonToolcacheLocation()
 
         if (Test-Path $pythonBinariesLocation) {
@@ -107,7 +110,7 @@ class PythonBuilder {
             Remove-Item $pythonBinariesLocation -Recurse -Force
         } else {
             Write-Host "Create $pythonBinariesLocation folder..."
-            New-Item -ItemType Directory -Path $pythonBinariesLocation 
+            New-Item -ItemType Directory -Path $pythonBinariesLocation
         }
     }
 }

--- a/builders/ubuntu-python-builder.psm1
+++ b/builders/ubuntu-python-builder.psm1
@@ -36,6 +36,9 @@ class UbuntuPythonBuilder : NixPythonBuilder {
         $configureString += " --prefix=$pythonBinariesLocation"
         $configureString += " --enable-shared"
         $configureString += " --enable-optimizations"
+        if ($this.WithPyDebug) {
+            $configureString += " --with-pydebug"
+        }
 
         ### Compile with support of loadable sqlite extensions.
         ### Link to documentation (https://docs.python.org/3/library/sqlite3.html#sqlite3.Connection.enable_load_extension)

--- a/builders/win-python-builder.psm1
+++ b/builders/win-python-builder.psm1
@@ -14,6 +14,9 @@ class WinPythonBuilder : PythonBuilder {
     .PARAMETER architecture
     The architecture with which Python should be built.
 
+    .PARAMETER WithPyDebug
+    The flag that indicates whether Python should be installed with debug symbols.
+
     .PARAMETER InstallationTemplateName
     The name of installation script template that will be used in generated artifact.
 
@@ -39,7 +42,7 @@ class WinPythonBuilder : PythonBuilder {
     [string] GetPythonExtension() {
         <#
         .SYNOPSIS
-        Return extension for required version of Python executable. 
+        Return extension for required version of Python executable.
         #>
 
         $extension = if ($this.Version -lt "3.5" -and $this.Version -ge "2.5") { ".msi" } else { ".exe" }
@@ -50,7 +53,7 @@ class WinPythonBuilder : PythonBuilder {
     [string] GetArchitectureExtension() {
         <#
         .SYNOPSIS
-        Return architecture suffix for Python executable. 
+        Return architecture suffix for Python executable.
         #>
 
         $ArchitectureExtension = ""
@@ -60,7 +63,7 @@ class WinPythonBuilder : PythonBuilder {
             } else {
                 $ArchitectureExtension = ".amd64"
             }
-        }elseif ($this.Architecture -eq "arm64") {
+        } elseif ($this.Architecture -eq "arm64") {
                 $ArchitectureExtension = "-arm64"
         }
 
@@ -114,7 +117,11 @@ class WinPythonBuilder : PythonBuilder {
         $variablesToReplace = @{
             "{{__ARCHITECTURE__}}" = $this.Architecture;
             "{{__VERSION__}}" = $this.Version;
-            "{{__PYTHON_EXEC_NAME__}}" = $pythonExecName
+            "{{__PYTHON_EXEC_NAME__}}" = $pythonExecName;
+            "{{__PYTHON_EXTRA_PARAMS__}}" = "";
+        }
+        if ($this.WithPyDebug) {
+            $variablesToReplace["{{__PYTHON_EXTRA_PARAMS__}}"] " Include_debug=1 Include_symbols=1"
         }
 
         $variablesToReplace.keys | ForEach-Object { $installationTemplateContent = $installationTemplateContent.Replace($_, $variablesToReplace[$_]) }

--- a/installers/win-setup-template.ps1
+++ b/installers/win-setup-template.ps1
@@ -1,6 +1,7 @@
 [String] $Architecture = "{{__ARCHITECTURE__}}"
 [String] $Version = "{{__VERSION__}}"
 [String] $PythonExecName = "{{__PYTHON_EXEC_NAME__}}"
+[String] $PythonExtraParams = "{{__PYTHON_EXTRA_PARAMS__}}"
 
 function Get-RegistryVersionFilter {
     param(
@@ -122,7 +123,7 @@ Copy-Item -Path ./$PythonExecName -Destination $PythonArchPath | Out-Null
 Write-Host "Install Python $Version in $PythonToolcachePath..."
 $ExecParams = Get-ExecParams -IsMSI $IsMSI -PythonArchPath $PythonArchPath
 
-cmd.exe /c "cd $PythonArchPath && call $PythonExecName $ExecParams /quiet"
+cmd.exe /c "cd $PythonArchPath && call $PythonExecName $ExecParams $PythonExtraParams /quiet"
 if ($LASTEXITCODE -ne 0) {
     Throw "Error happened during Python installation"
 }


### PR DESCRIPTION
Add [Python debug builds](https://docs.python.org/3/using/configure.html#python-debug-build) with [`Py_DEBUG` flag](https://docs.python.org/3/c-api/intro.html#c.Py_DEBUG) by setting [`--with-pydebug`](https://docs.python.org/3/using/configure.html#cmdoption-with-pydebug) and [`--with-trace-refs`](https://docs.python.org/3/using/configure.html#cmdoption-with-trace-refs) configure options.

Some advanced Python development features require the Python executable to be built with extra configure flags. For example:

- [`PYTHONDEBUG`](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONDEBUG) (command line option [`-d`](https://docs.python.org/3/using/cmdline.html#cmdoption-d)) requires [`--with-pydebug`](https://docs.python.org/3/using/configure.html#cmdoption-with-pydebug).
- [`-X showrefcount`](https://docs.python.org/3/using/cmdline.html#cmdoption-X) requires [`--with-pydebug`](https://docs.python.org/3/using/configure.html#cmdoption-with-pydebug).
- [`PYTHONDUMPREFS`](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONDUMPREFS) requires [`--with-trace-refs`](https://docs.python.org/3/using/configure.html#cmdoption-with-trace-refs).
- [`PYTHONDUMPREFSFILE=FILENAME`](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONDUMPREFS) requires [`--with-trace-refs`](https://docs.python.org/3/using/configure.html#cmdoption-with-trace-refs).

See also:

- actions/setup-python#885