### PR TITLE
Fix for the Codeql-analysis.yml workflow failure

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,5 +11,7 @@ on:
 jobs:
   call-codeQL-analysis:
     name: CodeQL analysis 
-    uses: aparnajyothi-y/reusable-workflows/.github/workflows/codeql-analysis.yml@fix-codeql-failure
+    uses: actions/reusable-workflows/.github/workflows/codeql-analysis.yml@main
+    with:
+     languages: '["python"]'
    

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,6 @@ on:
 jobs:
   call-codeQL-analysis:
     name: CodeQL analysis 
-    uses: actions/reusable-workflows/.github/workflows/codeql-analysis.yml@main
+    uses: aparnajyothi-y/reusable-workflows/.github/workflows/codeql-analysis.yml@fix-codeql-failure
     with:
      languages: "['python']"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,4 +13,4 @@ jobs:
     name: CodeQL analysis 
     uses: aparnajyothi-y/reusable-workflows/.github/workflows/codeql-analysis.yml@fix-codeql-failure
     with:
-     languages: "['python']"
+     languages: '["python"]'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,5 +12,4 @@ jobs:
   call-codeQL-analysis:
     name: CodeQL analysis 
     uses: aparnajyothi-y/reusable-workflows/.github/workflows/codeql-analysis.yml@fix-codeql-failure
-    with:
-     languages: '["python"]'
+   


### PR DESCRIPTION
This PR will resolve the CodeQL analysis failures.

This change modifies the languages input in the CodeQL check step. Previously, the value was set to default: "['Python']". However, this format causes a parsing error because JSON requires double quotes (") for strings. The updated line default: '["Python"]' fixes this issue by using double quotes for the array values, as required by JSON.