### PR TITLE
Fix for the build failures on the self-hosted Ubuntu 24.04 arm64 runner for no restart

### DIFF
--- a/.github/workflows/build-python-packages.yml
+++ b/.github/workflows/build-python-packages.yml
@@ -41,6 +41,7 @@ jobs:
         run: |
           [String[]]$configurations = "${{ inputs.platforms || 'ubuntu-20.04,ubuntu-22.04,ubuntu-22.04_arm64,ubuntu-24.04,ubuntu-24.04_arm64,macos-12,macos-14_arm64,windows-2019_x64,windows-2019_x86,windows-2019_arm64' }}".Split(",").Trim()
           $matrix = @()
+          
           foreach ($configuration in $configurations) {
             $parts = $configuration.Split("_")
             $os = $parts[0]
@@ -68,6 +69,7 @@ jobs:
             }
           }
           echo "matrix=$($matrix | ConvertTo-Json -Compress -AsArray)" >> $env:GITHUB_OUTPUT
+          
   build_python:
     needs: generate_matrix
     strategy:
@@ -100,6 +102,7 @@ jobs:
              # Install 7-Zip
             choco install 7zip -y
             echo "C:\ProgramData\chocolatey\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+            
       - name: Disable needrestart prompts
         if: matrix.os == 'setup-actions-ubuntu24-arm64-2-core'
         run: echo 'NEEDRESTART_MODE=a' | sudo tee /etc/needrestart/needrestart.conf
@@ -113,6 +116,7 @@ jobs:
         run: |
           ./builders/build-python.ps1 -Version $env:VERSION `
                   -Platform ${{ matrix.platform }} -Architecture ${{ matrix.arch }}
+                  
       - name: Publish artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-python-packages.yml
+++ b/.github/workflows/build-python-packages.yml
@@ -103,9 +103,6 @@ jobs:
             choco install 7zip -y
             echo "C:\ProgramData\chocolatey\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
             
-      - name: Disable needrestart prompts
-        if: matrix.os == 'setup-actions-ubuntu24-arm64-2-core'
-        run: echo 'NEEDRESTART_MODE=a' | sudo tee /etc/needrestart/needrestart.conf
 
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/build-python-packages.yml
+++ b/.github/workflows/build-python-packages.yml
@@ -41,7 +41,6 @@ jobs:
         run: |
           [String[]]$configurations = "${{ inputs.platforms || 'ubuntu-20.04,ubuntu-22.04,ubuntu-22.04_arm64,ubuntu-24.04,ubuntu-24.04_arm64,macos-12,macos-14_arm64,windows-2019_x64,windows-2019_x86,windows-2019_arm64' }}".Split(",").Trim()
           $matrix = @()
-
           foreach ($configuration in $configurations) {
             $parts = $configuration.Split("_")
             $os = $parts[0]
@@ -69,7 +68,6 @@ jobs:
             }
           }
           echo "matrix=$($matrix | ConvertTo-Json -Compress -AsArray)" >> $env:GITHUB_OUTPUT
-
   build_python:
     needs: generate_matrix
     strategy:
@@ -102,7 +100,9 @@ jobs:
              # Install 7-Zip
             choco install 7zip -y
             echo "C:\ProgramData\chocolatey\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
-
+      - name: Disable needrestart prompts
+        if: matrix.os == 'setup-actions-ubuntu24-arm64-2-core'
+        run: echo 'NEEDRESTART_MODE=a' | sudo tee /etc/needrestart/needrestart.conf
 
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -113,7 +113,6 @@ jobs:
         run: |
           ./builders/build-python.ps1 -Version $env:VERSION `
                   -Platform ${{ matrix.platform }} -Architecture ${{ matrix.arch }}
-
       - name: Publish artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
This PR changes should address the build failures on the self-hosted Ubuntu 24.04 arm64 runner for no restart. The changes include updating the `build-python-packages.yml` file to fix the issue.
