### PR TITLE
Remove EOL Python code, set 3.9 as base, add 3.14 stdlib module

### DIFF
--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -90,14 +90,10 @@ class macOSPythonBuilder : NixPythonBuilder {
             }
         }
 
-        ### Compile with support of loadable sqlite extensions. Unavailable for Python 2.*
-        ### Link to documentation (https://docs.python.org/3/library/sqlite3.html#sqlite3.Connection.enable_load_extension)
-        if ($this.Version -ge "3.2.0") {
-            $configureString += " --enable-loadable-sqlite-extensions"
-            $env:LDFLAGS += " -L$(brew --prefix sqlite3)/lib"
-            $env:CFLAGS += " -I$(brew --prefix sqlite3)/include"
-            $env:CPPFLAGS += "-I$(brew --prefix sqlite3)/include"
-        }
+        $configureString += " --enable-loadable-sqlite-extensions"
+        $env:LDFLAGS += " -L$(brew --prefix sqlite3)/lib"
+        $env:CFLAGS += " -I$(brew --prefix sqlite3)/include"
+        $env:CPPFLAGS += "-I$(brew --prefix sqlite3)/include"
 
         Write-Host "The passed configure options are: "
         Write-Host $configureString

--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -67,27 +67,22 @@ class macOSPythonBuilder : NixPythonBuilder {
         ### Solution is to install these libraries from a third-party package manager,
         ### and then add the appropriate paths for the header and library files to configure command.
         ### Link to documentation (https://cpython-devguide.readthedocs.io/setup/#build-dependencies)
-        if ($this.Version -lt "3.7.0") {
-            $env:LDFLAGS = "-L/usr/local/opt/openssl@1.1/lib -L/usr/local/opt/zlib/lib"
-            $env:CFLAGS = "-I/usr/local/opt/openssl@1.1/include -I/usr/local/opt/zlib/include"
-        } else {
-            $configureString += " --with-openssl=/usr/local/opt/openssl@1.1"
+        $configureString += " --with-openssl=/usr/local/opt/openssl@1.1"
 
-            # For Python 3.7.2 and 3.7.3 we need to provide PATH for zlib to pack it properly. Otherwise the build will fail
-            # with the error: zipimport.ZipImportError: can't decompress data; zlib not available
-            if ($this.Version -eq "3.7.2" -or $this.Version -eq "3.7.3" -or $this.Version -eq "3.7.17") {
-                $env:LDFLAGS = "-L/usr/local/opt/zlib/lib"
-                $env:CFLAGS = "-I/usr/local/opt/zlib/include"
-            }
+        # For Python 3.7.2 and 3.7.3 we need to provide PATH for zlib to pack it properly. Otherwise the build will fail
+        # with the error: zipimport.ZipImportError: can't decompress data; zlib not available
+        if ($this.Version -eq "3.7.2" -or $this.Version -eq "3.7.3" -or $this.Version -eq "3.7.17") {
+            $env:LDFLAGS = "-L/usr/local/opt/zlib/lib"
+            $env:CFLAGS = "-I/usr/local/opt/zlib/include"
+        }
 
-            if ($this.Version -gt "3.7.12") {
-                $configureString += " --with-tcltk-includes='-I /usr/local/opt/tcl-tk/include' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6'"
-	        }
+        if ($this.Version -gt "3.7.12") {
+            $configureString += " --with-tcltk-includes='-I /usr/local/opt/tcl-tk/include' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6'"
+        }
 
-            if ($this.Version -eq "3.7.17") {
-                $env:LDFLAGS += " -L$(brew --prefix bzip2)/lib -L$(brew --prefix readline)/lib -L$(brew --prefix ncurses)/lib"
-                $env:CFLAGS += " -I$(brew --prefix bzip2)/include -I$(brew --prefix readline)/include -I$(brew --prefix ncurses)/include"
-            }
+        if ($this.Version -eq "3.7.17") {
+            $env:LDFLAGS += " -L$(brew --prefix bzip2)/lib -L$(brew --prefix readline)/lib -L$(brew --prefix ncurses)/lib"
+            $env:CFLAGS += " -I$(brew --prefix bzip2)/include -I$(brew --prefix readline)/include -I$(brew --prefix ncurses)/include"
         }
 
         $configureString += " --enable-loadable-sqlite-extensions"

--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -31,14 +31,6 @@ class macOSPythonBuilder : NixPythonBuilder {
         .SYNOPSIS
         Prepare system environment by installing dependencies and required packages.
         #>
-        
-        if ($this.Version -eq "3.7.17") {
-            # We have preinstalled ncurses and readLine on the hoster runners. But we need to install bzip2 for 
-            # setting up an environemnt 
-            # If we get any issues realted to ncurses or readline we can try to run this command
-            # brew install ncurses readline
-            Execute-Command -Command "brew install bzip2"
-        }
     }
 
     [void] Configure() {
@@ -68,23 +60,7 @@ class macOSPythonBuilder : NixPythonBuilder {
         ### and then add the appropriate paths for the header and library files to configure command.
         ### Link to documentation (https://cpython-devguide.readthedocs.io/setup/#build-dependencies)
         $configureString += " --with-openssl=/usr/local/opt/openssl@1.1"
-
-        # For Python 3.7.2 and 3.7.3 we need to provide PATH for zlib to pack it properly. Otherwise the build will fail
-        # with the error: zipimport.ZipImportError: can't decompress data; zlib not available
-        if ($this.Version -eq "3.7.2" -or $this.Version -eq "3.7.3" -or $this.Version -eq "3.7.17") {
-            $env:LDFLAGS = "-L/usr/local/opt/zlib/lib"
-            $env:CFLAGS = "-I/usr/local/opt/zlib/include"
-        }
-
-        if ($this.Version -gt "3.7.12") {
-            $configureString += " --with-tcltk-includes='-I /usr/local/opt/tcl-tk/include' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6'"
-        }
-
-        if ($this.Version -eq "3.7.17") {
-            $env:LDFLAGS += " -L$(brew --prefix bzip2)/lib -L$(brew --prefix readline)/lib -L$(brew --prefix ncurses)/lib"
-            $env:CFLAGS += " -I$(brew --prefix bzip2)/include -I$(brew --prefix readline)/include -I$(brew --prefix ncurses)/include"
-        }
-
+        $configureString += " --with-tcltk-includes='-I /usr/local/opt/tcl-tk/include' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6'"
         $configureString += " --enable-loadable-sqlite-extensions"
         $env:LDFLAGS += " -L$(brew --prefix sqlite3)/lib"
         $env:CFLAGS += " -I$(brew --prefix sqlite3)/include"

--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -50,10 +50,6 @@ class macOSPythonBuilder : NixPythonBuilder {
         ### will never be used itself by a Github Actions runner but using a universal2 Python is the only way to build
         ### universal2 C extensions and wheels. This is supported by Python >= 3.10 and was backported to Python >=
         ### 3.9.1 and >= 3.8.10.
-        ### Disabled, discussion: https://github.com/actions/python-versions/pull/114
-        # if ($this.Version -ge "3.8.10" -and $this.Version -ne "3.8.13" -and $this.Version -ne "3.9.0" ) {
-        #     $configureString += " --enable-universalsdk --with-universal-archs=universal2"
-        # }
 
         ### OS X 10.11, Apple no longer provides header files for the deprecated system version of OpenSSL.
         ### Solution is to install these libraries from a third-party package manager,

--- a/builders/nix-python-builder.psm1
+++ b/builders/nix-python-builder.psm1
@@ -61,8 +61,7 @@ class NixPythonBuilder : PythonBuilder {
         Return name of Python binary.
         #>
 
-        if ($this.Version.Major -eq 2) { $pythonBinary = "python" } else { $pythonBinary = "python3" }
-        return $pythonBinary
+        return "python3"
     }
 
     [string] Download() {

--- a/builders/ubuntu-python-builder.psm1
+++ b/builders/ubuntu-python-builder.psm1
@@ -53,8 +53,8 @@ class UbuntuPythonBuilder : NixPythonBuilder {
         Prepare system environment by installing dependencies and required packages.
         #>
 
-        if ($this.Version -lt "3.5.3") {
-            Write-Host "Python versions lower than 3.5.3 are not supported"
+        if ($this.Version -lt "3.9.0") {
+            Write-Host "Python versions lower than 3.9.0 are not supported"
             exit 1
         }
 

--- a/builders/win-python-builder.psm1
+++ b/builders/win-python-builder.psm1
@@ -55,11 +55,7 @@ class WinPythonBuilder : PythonBuilder {
 
         $ArchitectureExtension = ""
         if ($this.Architecture -eq "x64") {
-            if ($this.Version -ge "3.5") {
-                $ArchitectureExtension = "-amd64"
-            } else {
-                $ArchitectureExtension = ".amd64"
-            }
+            $ArchitectureExtension = "-amd64"
         }elseif ($this.Architecture -eq "arm64") {
                 $ArchitectureExtension = "-arm64"
         }

--- a/builders/win-python-builder.psm1
+++ b/builders/win-python-builder.psm1
@@ -42,9 +42,7 @@ class WinPythonBuilder : PythonBuilder {
         Return extension for required version of Python executable. 
         #>
 
-        $extension = if ($this.Version -lt "3.5" -and $this.Version -ge "2.5") { ".msi" } else { ".exe" }
-
-        return $extension
+        return ".exe"
     }
 
     [string] GetArchitectureExtension() {

--- a/installers/win-setup-template.ps1
+++ b/installers/win-setup-template.ps1
@@ -10,12 +10,7 @@ function Get-RegistryVersionFilter {
     )
 
     $archFilter = if ($Architecture -eq 'x86') { "32-bit" } else { "64-bit" }
-    ### Python 2.7 x86 have no architecture postfix
-    if (($Architecture -eq "x86") -and ($MajorVersion -eq 2)) {
-        "Python $MajorVersion.$MinorVersion.\d+$"
-    } else {
-        "Python $MajorVersion.$MinorVersion.*($archFilter)"
-    }
+    "Python $MajorVersion.$MinorVersion.*($archFilter)"
 }
 
 function Remove-RegistryEntries {
@@ -128,9 +123,7 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 Write-Host "Create `python3` symlink"
-if ($MajorVersion -ne "2") {
-    New-Item -Path "$PythonArchPath\python3.exe" -ItemType SymbolicLink -Value "$PythonArchPath\python.exe"
-}
+New-Item -Path "$PythonArchPath\python3.exe" -ItemType SymbolicLink -Value "$PythonArchPath\python.exe"
 
 Write-Host "Install and upgrade Pip"
 $Env:PIP_ROOT_USER_ACTION = "ignore"

--- a/tests/python-tests.ps1
+++ b/tests/python-tests.ps1
@@ -90,16 +90,6 @@ Describe "Tests" {
         }
     }
 
-    # Pyinstaller 3.5 does not support Python 3.8.0. Check issue https://github.com/pyinstaller/pyinstaller/issues/4311
-    if ($Version -lt "3.8.0" -and $Version.Major -ne "2") {
-        It "Validate Pyinstaller" {
-            "pip install pyinstaller" | Should -ReturnZeroExitCode
-            "pyinstaller --onefile ./sources/simple-test.py" | Should -ReturnZeroExitCode
-            $distPath = [IO.Path]::Combine($pwd, "dist", "simple-test")
-            "$distPath" | Should -ReturnZeroExitCode
-        }
-    }
-
     It "Check urlopen with HTTPS works" {
         "python ./sources/python-urlopen-https.py" | Should -ReturnZeroExitCode
     }

--- a/tests/python-tests.ps1
+++ b/tests/python-tests.ps1
@@ -60,7 +60,7 @@ Describe "Tests" {
     #     }
     # }
 
-    if ($Version -lt "3.11.0") -and (($Platform -ne "darwin") -or ($HardwareArchitecture -ne "arm64"))) {
+    if (($Version -lt "3.11.0") -and (($Platform -ne "darwin") -or ($HardwareArchitecture -ne "arm64"))) {
         It "Check if sqlite3 module is installed" {
             "python ./sources/python-sqlite3.py" | Should -ReturnZeroExitCode
         }

--- a/tests/python-tests.ps1
+++ b/tests/python-tests.ps1
@@ -58,7 +58,7 @@ Describe "Tests" {
     #     }
     # }
 
-    if (($Version -ge "3.2.0") -and ($Version -lt "3.11.0") -and (($Platform -ne "darwin") -or ($Architecture -ne "arm64"))) {
+    if ($Version -lt "3.11.0") -and (($Platform -ne "darwin") -or ($Architecture -ne "arm64"))) {
         It "Check if sqlite3 module is installed" {
             "python ./sources/python-sqlite3.py" | Should -ReturnZeroExitCode
         }

--- a/tests/sources/python-modules.py
+++ b/tests/sources/python-modules.py
@@ -6,7 +6,7 @@ This is needed for Linux since we build from source.
 import importlib
 import sys
 
-# The Python standard library as of Python 3.2
+# The Python standard library as of Python 3.3
 standard_library = [
     'abc',
     'aifc',
@@ -51,6 +51,7 @@ standard_library = [
     'dummy_threading',
     'email',
     'encodings',
+    'faulthandler',
     'filecmp',
     'fileinput',
     'fnmatch',
@@ -76,12 +77,14 @@ standard_library = [
     'importlib',
     'inspect',
     'io',
+    'ipaddress',
     'json',
     'keyword',
     'lib2to3',
     'linecache',
     'locale',
     'logging',
+    'lzma',
     'macpath',
     'mailbox',
     'mailcap',
@@ -170,6 +173,7 @@ standard_library = [
     'urllib',
     'uu',
     'uuid',
+    'venv',
     'warnings',
     'wave',
     'weakref',
@@ -183,14 +187,6 @@ standard_library = [
 
 # Add new modules
 # See https://docs.python.org/3/whatsnew/index.html
-if sys.version_info >= (3, 3):
-    standard_library.extend([
-        'ipaddress',
-        'faulthandler',
-        'lzma',
-        'venv',
-    ])
-
 if sys.version_info >= (3, 4):
     standard_library.extend([
         'asyncio',

--- a/tests/sources/python-modules.py
+++ b/tests/sources/python-modules.py
@@ -6,7 +6,7 @@ This is needed for Linux since we build from source.
 import importlib
 import sys
 
-# The Python standard library as of Python 3.6
+# The Python standard library as of Python 3.7
 standard_library = [
     'abc',
     'aifc',
@@ -36,12 +36,14 @@ standard_library = [
     'concurrent',
     'configparser',
     'contextlib',
+    'contextvars',
     'copy',
     'copyreg',
     'crypt',
     'csv',
     'ctypes',
     'curses',
+    'dataclasses',
     'datetime',
     'dbm',
     'decimal',
@@ -197,12 +199,6 @@ standard_library = [
 
 # Add new modules
 # See https://docs.python.org/3/whatsnew/index.html
-if sys.version_info >= (3, 7):
-    standard_library.extend([
-        'contextvars',
-        'dataclasses',
-    ])
-
 # 'macpath' module has been removed from Python 3.8
 if sys.version_info > (3, 7):
     standard_library.remove('macpath')

--- a/tests/sources/python-modules.py
+++ b/tests/sources/python-modules.py
@@ -236,6 +236,11 @@ if sys.version_info >= (3, 13):
     standard_library.remove('uu')
     standard_library.remove('xdrlib')
 
+if sys.version_info >= (3, 14):
+    standard_library.extend([
+        'annotationlib',
+    ])
+
 # Remove tkinter and Easter eggs
 excluded_modules = [
     'antigravity',

--- a/tests/sources/python-modules.py
+++ b/tests/sources/python-modules.py
@@ -3,8 +3,6 @@ Make sure all the optional modules are installed.
 This is needed for Linux since we build from source.
 """
 
-from __future__ import print_function
-
 import importlib
 import sys
 
@@ -181,29 +179,6 @@ standard_library = [
     'xmlrpc',
     'zipfile'
 ]
-
-# Modules that had different names in Python 2
-if sys.version_info.major == 2:
-    def replace(lst, old, new):
-        lst[lst.index(old)] = new
-
-    # Keys are the Python 2 names
-    # Values are the Python 3 names
-    renames = {
-        'ConfigParser': 'configparser',
-        'copy_reg': 'copyreg',
-        'HTMLParser': 'html',
-        'httplib': 'http',
-        'Queue': 'queue',
-        'repr': 'reprlib',
-        'SocketServer': 'socketserver',
-        'xmlrpclib': 'xmlrpc',
-        'Tkinter': 'tkinter'
-    }
-
-    # All of the Python 3 names should be in the list
-    for python2name, python3name in renames.items():
-        replace(standard_library, python3name, python2name)
 
 # Add new modules
 # See https://docs.python.org/3/whatsnew/index.html

--- a/tests/sources/python-modules.py
+++ b/tests/sources/python-modules.py
@@ -6,7 +6,7 @@ This is needed for Linux since we build from source.
 import importlib
 import sys
 
-# The Python standard library as of Python 3.3
+# The Python standard library as of Python 3.4
 standard_library = [
     'abc',
     'aifc',
@@ -15,6 +15,7 @@ standard_library = [
     'ast',
     'asynchat',
     'asyncore',
+    'asyncio',
     'base64',
     'bdb',
     'binhex',
@@ -51,6 +52,8 @@ standard_library = [
     'dummy_threading',
     'email',
     'encodings',
+    'ensurepip',
+    'enum',
     'faulthandler',
     'filecmp',
     'fileinput',
@@ -100,6 +103,7 @@ standard_library = [
     'operator',
     'optparse',
     'os',
+    'pathlib',
     'pdb',
     'pickle',
     'pickletools',
@@ -126,6 +130,7 @@ standard_library = [
     'rlcompleter',
     'runpy',
     'sched',
+    'selectors',
     'shelve',
     'shlex',
     'shutil',
@@ -143,6 +148,7 @@ standard_library = [
     'ssl',
     '_ssl',
     'stat',
+    'statistics',
     'string',
     'stringprep',
     'struct',
@@ -165,6 +171,7 @@ standard_library = [
     'tokenize',
     'trace',
     'traceback',
+    'tracemalloc',
     'tty',
     'turtle',
     'turtledemo',
@@ -187,17 +194,6 @@ standard_library = [
 
 # Add new modules
 # See https://docs.python.org/3/whatsnew/index.html
-if sys.version_info >= (3, 4):
-    standard_library.extend([
-        'asyncio',
-        'ensurepip',
-        'enum',
-        'pathlib',
-        'selectors',
-        'statistics',
-        'tracemalloc',
-    ])
-
 if sys.version_info >= (3, 5):
     standard_library.extend([
         'typing',

--- a/tests/sources/python-modules.py
+++ b/tests/sources/python-modules.py
@@ -6,7 +6,7 @@ This is needed for Linux since we build from source.
 import importlib
 import sys
 
-# The Python standard library as of Python 3.7
+# The Python standard library as of Python 3.8
 standard_library = [
     'abc',
     'aifc',
@@ -90,7 +90,6 @@ standard_library = [
     'locale',
     'logging',
     'lzma',
-    'macpath',
     'mailbox',
     'mailcap',
     'mimetypes',
@@ -199,10 +198,6 @@ standard_library = [
 
 # Add new modules
 # See https://docs.python.org/3/whatsnew/index.html
-# 'macpath' module has been removed from Python 3.8
-if sys.version_info > (3, 7):
-    standard_library.remove('macpath')
-
 # 'dummy_threading' module has been removed from Python 3.9
 if sys.version_info > (3, 8):
     standard_library.remove('dummy_threading')

--- a/tests/sources/python-modules.py
+++ b/tests/sources/python-modules.py
@@ -6,7 +6,7 @@ This is needed for Linux since we build from source.
 import importlib
 import sys
 
-# The Python standard library as of Python 3.4
+# The Python standard library as of Python 3.5
 standard_library = [
     'abc',
     'aifc',
@@ -176,6 +176,7 @@ standard_library = [
     'turtle',
     'turtledemo',
     'types',
+    'typing',
     'unittest',
     'urllib',
     'uu',
@@ -189,17 +190,12 @@ standard_library = [
     'xdrlib',
     'xml',
     'xmlrpc',
+    'zipapp',
     'zipfile'
 ]
 
 # Add new modules
 # See https://docs.python.org/3/whatsnew/index.html
-if sys.version_info >= (3, 5):
-    standard_library.extend([
-        'typing',
-        'zipapp',
-    ])
-
 if sys.version_info >= (3, 6):
     standard_library.extend([
         'secrets',

--- a/tests/sources/python-modules.py
+++ b/tests/sources/python-modules.py
@@ -6,7 +6,7 @@ This is needed for Linux since we build from source.
 import importlib
 import sys
 
-# The Python standard library as of Python 3.0
+# The Python standard library as of Python 3.2
 standard_library = [
     'abc',
     'aifc',
@@ -32,6 +32,7 @@ standard_library = [
     'collections',
     'colorsys',
     'compileall',
+    'concurrent',
     'configparser',
     'contextlib',
     'copy',
@@ -182,11 +183,6 @@ standard_library = [
 
 # Add new modules
 # See https://docs.python.org/3/whatsnew/index.html
-if sys.version_info >= (3, 2):
-    standard_library.extend([
-        'concurrent',
-    ])
-
 if sys.version_info >= (3, 3):
     standard_library.extend([
         'ipaddress',

--- a/tests/sources/python-modules.py
+++ b/tests/sources/python-modules.py
@@ -6,7 +6,7 @@ This is needed for Linux since we build from source.
 import importlib
 import sys
 
-# The Python standard library as of Python 3.5
+# The Python standard library as of Python 3.6
 standard_library = [
     'abc',
     'aifc',
@@ -130,6 +130,7 @@ standard_library = [
     'rlcompleter',
     'runpy',
     'sched',
+    'secrets',
     'selectors',
     'shelve',
     'shlex',
@@ -196,11 +197,6 @@ standard_library = [
 
 # Add new modules
 # See https://docs.python.org/3/whatsnew/index.html
-if sys.version_info >= (3, 6):
-    standard_library.extend([
-        'secrets',
-    ])
-
 if sys.version_info >= (3, 7):
     standard_library.extend([
         'contextvars',

--- a/tests/sources/python-modules.py
+++ b/tests/sources/python-modules.py
@@ -6,7 +6,7 @@ This is needed for Linux since we build from source.
 import importlib
 import sys
 
-# The Python standard library as of Python 3.8
+# The Python standard library as of Python 3.9
 standard_library = [
     'abc',
     'aifc',
@@ -51,7 +51,6 @@ standard_library = [
     'dis',
     'distutils',
     'doctest',
-    'dummy_threading',
     'email',
     'encodings',
     'ensurepip',
@@ -198,10 +197,6 @@ standard_library = [
 
 # Add new modules
 # See https://docs.python.org/3/whatsnew/index.html
-# 'dummy_threading' module has been removed from Python 3.9
-if sys.version_info > (3, 8):
-    standard_library.remove('dummy_threading')
-
 # 'symbol' and 'formatter' modules have been removed from Python 3.10
 if sys.version_info >= (3, 10):
     standard_library.remove('symbol')

--- a/tests/sources/python-urlopen-https.py
+++ b/tests/sources/python-urlopen-https.py
@@ -1,9 +1,5 @@
 import sys
-
-if sys.version_info[0] == 2:
-    from urllib2 import urlopen
-else:
-    from urllib.request import urlopen
+from urllib.request import urlopen
 
 response = urlopen("https://raw.githubusercontent.com/actions/python-versions/c641695f6a07526c18f10e374e503e649fef9427/.gitignore")
 data = response.read()


### PR DESCRIPTION
Python 2 is end-of-life and no longer supported by GitHub Actions, so remove the special handling for it.

Python 3.9 is the oldest non-EOL version, so set 3.9 as the base version.

https://devguide.python.org/versions/

Finally, `annotationlib` is a new module in the 3.14 stdlib, add it.

https://docs.python.org/3.14/whatsnew/3.14.html#new-modules