### PR TITLE
Replace deprecated actions/create-release with gh release create

### DIFF
--- a/.github/workflows/build-python-packages.yml
+++ b/.github/workflows/build-python-packages.yml
@@ -238,14 +238,18 @@ jobs:
 
       - name: Publish Release ${{ env.VERSION }}
         id: create_release
-        uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.VERSION }}-${{ github.run_id }}
-          release_name: ${{ env.VERSION }}
-          body: |
-            Python ${{ env.VERSION }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          tag_name="${{ env.VERSION }}-${{ github.run_id }}"
+          gh release create "$tag_name" \
+            --repo="$GITHUB_REPOSITORY" \
+            --title="${{ env.VERSION }}" \
+            --notes="Python ${{ env.VERSION }}"
+            
+          release_id=$(gh release view "$tag_name" --repo "$GITHUB_REPOSITORY" --json databaseId --jq '.databaseId')
+          echo "id=$release_id" >> $GITHUB_OUTPUT          
 
       - name: Generate hash for packages
         run: |


### PR DESCRIPTION
This PR replaces the deprecated `actions/create-release` with the [gh release create](https://cli.github.com/manual/gh_release_create) command using the GitHub CLI.