### PR TITLE
Fix tkinter issues for old versions

### DIFF
--- a/.github/workflows/build-python-packages.yml
+++ b/.github/workflows/build-python-packages.yml
@@ -109,6 +109,10 @@ jobs:
         with:
           submodules: true
 
+      - name: Adding Symlink
+        if: matrix.os == 'macos-13'
+        run: ln -sf /usr/local/opt/tcl-tk@8 /usr/local/opt/tcl-tk
+
       - name: Build Python ${{ env.VERSION }}
         run: |
           ./builders/build-python.ps1 -Version $env:VERSION `

--- a/builders/macos-python-builder.psm1
+++ b/builders/macos-python-builder.psm1
@@ -80,9 +80,9 @@ class macOSPythonBuilder : NixPythonBuilder {
                 $env:CFLAGS = "-I/usr/local/opt/zlib/include"
             }
 
-            if ($this.Version -gt "3.7.12") {
-                $configureString += " --with-tcltk-includes='-I /usr/local/opt/tcl-tk/include' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6'"
-	        }
+            # if ($this.Version -gt "3.7.12") {
+                $configureString += " --with-tcltk-includes='-I /usr/local/opt/tcl-tk/include/tcl-tk' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6'"
+            # }
 
             if ($this.Version -eq "3.7.17") {
                 $env:LDFLAGS += " -L$(brew --prefix bzip2)/lib -L$(brew --prefix readline)/lib -L$(brew --prefix ncurses)/lib"


### PR DESCRIPTION
This PR will fix the "`missing module: tkinter`" issue on macos-13 by adding symlink to the code. This PR will help in generating new artifacts for versions less than 3.11 on macos x64 runners.