### PR TITLE
chore: use ubuntu-*-arm runners instead of custom ones

### DIFF
--- a/.github/workflows/build-python-packages.yml
+++ b/.github/workflows/build-python-packages.yml
@@ -54,18 +54,12 @@ jobs:
               $os = $parts[0]
               $arch = if ($parts[1]) {$parts[1]} else {"x64"}
               switch -wildcard ($os) {
-                "*ubuntu*" { $platform = $os.Replace("ubuntu","linux")}
+                "*ubuntu*" { $platform = $os.Replace("ubuntu","linux"); if ($arch -eq "arm64" ) { $os = "${os}-arm" } }
                 "*macos*" { $platform = 'darwin' }
                 "*windows*" { $platform = 'win32' }
               }
 
-              if ($configuration -eq "ubuntu-22.04_arm64") {
-                $os = "setup-actions-ubuntu-arm64-2-core"
-              }
-              elseif ($configuration -eq "ubuntu-24.04_arm64") {
-                $os = "setup-actions-ubuntu24-arm64-2-core"
-              }
-              elseif ($configuration -eq "windows-2019_arm64") {
+              if ($configuration -eq "windows-2019_arm64") {
                 $os = "setup-actions-windows-arm64-4-core"
               }
 


### PR DESCRIPTION
This allows contributors to test on GitHub hosted Linux ARM64 runners easily now that those runners are available for free for public repositories:
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/