### PR TITLE
fix: Added quotes to unquoted paths in python install and pip upgrade commands

### DIFF
--- a/installers/win-setup-template.ps1
+++ b/installers/win-setup-template.ps1
@@ -138,7 +138,7 @@ New-Item -Path "$PythonArchPath\python3.exe" -ItemType SymbolicLink -Value "$Pyt
 Write-Host "Install and upgrade Pip"
 $Env:PIP_ROOT_USER_ACTION = "ignore"
 $PythonExePath = Join-Path -Path $PythonArchPath -ChildPath "python.exe"
-cmd.exe /c "$PythonExePath -m ensurepip && $PythonExePath -m pip install --upgrade --force-reinstall pip --no-warn-script-location"
+cmd.exe /c "`"$PythonExePath`" -m ensurepip && `"$PythonExePath`" -m pip install --upgrade --force-reinstall pip --no-warn-script-location"
 if ($LASTEXITCODE -ne 0) {
     Throw "Error happened during pip installation / upgrade"
 }

--- a/installers/win-setup-template.ps1
+++ b/installers/win-setup-template.ps1
@@ -121,7 +121,7 @@ Copy-Item -Path ./$PythonExecName -Destination $PythonArchPath | Out-Null
 Write-Host "Install Python $Version in $PythonToolcachePath..."
 $ExecParams = Get-ExecParams -IsMSI $IsMSI -IsFreeThreaded $IsFreeThreaded -PythonArchPath $PythonArchPath
 
-cmd.exe /c "cd $PythonArchPath && call $PythonExecName $ExecParams /quiet"
+cmd.exe /c "cd `"$PythonArchPath`" && call `"$PythonExecName`" $ExecParams /quiet"
 if ($LASTEXITCODE -ne 0) {
     Throw "Error happened during Python installation"
 }

--- a/installers/win-setup-template.ps1
+++ b/installers/win-setup-template.ps1
@@ -62,10 +62,10 @@ function Get-ExecParams {
     )
 
     if ($IsMSI) {
-        "TARGETDIR=$PythonArchPath ALLUSERS=1"
+        "TARGETDIR=`"$PythonArchPath`" ALLUSERS=1"
     } else {
         $Include_freethreaded = if ($IsFreeThreaded) { "Include_freethreaded=1" } else { "" }
-        "DefaultAllUsersTargetDir=$PythonArchPath InstallAllUsers=1 $Include_freethreaded"
+        "DefaultAllUsersTargetDir=`"$PythonArchPath`" InstallAllUsers=1 $Include_freethreaded"
     }
 }
 


### PR DESCRIPTION
Added backtick commented out quotes for python install and pip upgrade steps to avoid errors when the hosted tools path has a space in it.