### PR TITLE
Permission denied when creating symlinks on macOS self-hosted runners

### DIFF
--- a/installers/macos-pkg-setup-template.sh
+++ b/installers/macos-pkg-setup-template.sh
@@ -69,18 +69,18 @@ cd bin/
 # This symlink already exists if Python version with the same major.minor version is installed,
 # since we do not remove the framework folder
 if [ ! -f $PYTHON_MAJOR_MINOR ]; then
-    ln -s $PYTHON_MAJOR_DOT_MINOR $PYTHON_MAJOR_MINOR
+    sudo ln -s $PYTHON_MAJOR_DOT_MINOR $PYTHON_MAJOR_MINOR
 fi
 
 if [ ! -f $PYTHON_MAJOR ]; then
-    ln -s $PYTHON_MAJOR_DOT_MINOR $PYTHON_MAJOR
+    sudo ln -s $PYTHON_MAJOR_DOT_MINOR $PYTHON_MAJOR
 fi
 
 if [ ! -f python ]; then
-    ln -s $PYTHON_MAJOR_DOT_MINOR python
+    sudo ln -s $PYTHON_MAJOR_DOT_MINOR python
 fi
 
-chmod +x $PYTHON_MAJOR $PYTHON_MAJOR_DOT_MINOR $PYTHON_MAJOR_MINOR python
+sudo chmod +x $PYTHON_MAJOR $PYTHON_MAJOR_DOT_MINOR $PYTHON_MAJOR_MINOR python
 
 echo "Upgrading pip..."
 export PIP_ROOT_USER_ACTION=ignore


### PR DESCRIPTION
### Problem
`setup-python` fails on self-hosted macOS EC2 runners with:
```
Error: ln: python314: Permission denied
```

<img width="1197" height="547" alt="image" src="https://github.com/user-attachments/assets/0811f4b6-ffae-482e-9be1-81b279ad4a80" />


The `setup.sh` installer script uses `sudo` to install the Python framework into `/Library/Frameworks/` (line 50), but the subsequent symlink creation inside that root-owned directory runs **without** `sudo`, causing a permission error on runners where the CI user is not an admin.
