### PR TITLE
Update architecture filter for arm64 installer

### DIFF
--- a/installers/win-setup-template.ps1
+++ b/installers/win-setup-template.ps1
@@ -10,7 +10,12 @@ function Get-RegistryVersionFilter {
         [Parameter(Mandatory)][Int32] $MinorVersion
     )
 
-    $archFilter = if ($Architecture -eq 'x86') { "32-bit" } else { "64-bit" }
+    # ARM64 Python installer registers as "(ARM64)" in the display name, not "(64-bit)"
+    $archFilter = switch ($Architecture) {
+        'x86'   { "32-bit" }
+        'arm64' { "64-bit|ARM64" }
+        default { "64-bit" }
+    }    
     "Python $MajorVersion.$MinorVersion.*($archFilter)"
 }
 


### PR DESCRIPTION
**Problem**

The Python ARM64 installer registers its display name suffix as (ARM64) (for example, "Python 3.14.4 (ARM64)") instead of the more generic (64-bit). As a result, the Remove-RegistryEntries script fails to identify and clean up these ARM64-specific registry entries. This can leave behind stale Windows Installer registrations, which subsequently prevent new installations of Python on ARM64 systems.

**Solution**

This change updates the logic in Remove-RegistryEntries to properly match and remove ARM64 installer entries by recognizing the (ARM64) suffix. With this fix, stale registry records will be correctly cleared, ensuring that new Python installations on Windows ARM64 are not blocked by previous residual entries.