### PR TITLE
Add support for Ubuntu 26.04 runner in build workflow

### DIFF
--- a/.github/workflows/build-python-packages.yml
+++ b/.github/workflows/build-python-packages.yml
@@ -20,7 +20,7 @@ on:
       PLATFORMS:
         description: 'Platforms for execution in "os" or "os_arch" format (arch is "x64" by default)'
         required: true
-        default: 'ubuntu-22.04,ubuntu-22.04_arm64,ubuntu-24.04,ubuntu-24.04_arm64,rhel-9,rhel-10,macos-15-intel_x64,macos-14_arm64,windows-2022_x64,windows-2022_x86,windows-11_arm64'
+        default: 'ubuntu-22.04,ubuntu-22.04_arm64,ubuntu-24.04,ubuntu-24.04_arm64,ubuntu-26.04,ubuntu-26.04_arm64,rhel-9,rhel-10,macos-15-intel_x64,macos-14_arm64,windows-2022_x64,windows-2022_x86,windows-11_arm64'
   pull_request:
     paths-ignore:
     - 'versions-manifest.json'
@@ -44,7 +44,7 @@ jobs:
       - name: Generate execution matrix
         id: generate-matrix
         run: |
-          [String[]]$configurations = "${{ inputs.platforms || 'ubuntu-22.04,ubuntu-22.04_arm64,ubuntu-24.04,ubuntu-24.04_arm64,rhel-9,rhel-10,macos-15-intel,macos-14_arm64,windows-2022_x64,windows-2022_x86,windows-11_arm64' }}".Split(",").Trim()
+          [String[]]$configurations = "${{ inputs.platforms || 'ubuntu-22.04,ubuntu-22.04_arm64,ubuntu-24.04,ubuntu-24.04_arm64,ubuntu-26.04,ubuntu-26.04_arm64,rhel-9,rhel-10,macos-15-intel,macos-14_arm64,windows-2022_x64,windows-2022_x86,windows-11_arm64' }}".Split(",").Trim()
           [String[]]$buildModes = "${{ inputs.threading_build_modes || 'default' }}".Split(",").Trim()
           $matrix = @()
           


### PR DESCRIPTION
This pull request updates the default runner label list to include support for `ubuntu-26.04` and `ubuntu-26.04_arm64`