### PR TITLE
Install libcrypt-dev on Ubuntu 26.04 for Python 3.10-3.12 builds 

### DIFF
--- a/builders/ubuntu-python-builder.psm1
+++ b/builders/ubuntu-python-builder.psm1
@@ -92,7 +92,9 @@ class UbuntuPythonBuilder : NixPythonBuilder {
         Execute-Command -Command "sudo apt install -y libgdbm-compat-dev"
 
         ### Python 3.10-3.12 need libcrypt-dev (crypt.h) which is not installed by default on Ubuntu 26.04
-        if ($this.Version -ge "3.10.0" -and $this.Version -lt "3.13.0" -and $this.Platform -match "26\.04") {
+        if ([semver]"$($this.Version.Major).$($this.Version.Minor)" -ge [semver]"3.10" -and
+            [semver]"$($this.Version.Major).$($this.Version.Minor)" -lt [semver]"3.13" -and
+            $this.Platform -match "26\.04") {
             Execute-Command -Command "sudo apt install -y libcrypt-dev"
         }
     }

--- a/builders/ubuntu-python-builder.psm1
+++ b/builders/ubuntu-python-builder.psm1
@@ -90,5 +90,10 @@ class UbuntuPythonBuilder : NixPythonBuilder {
 
         ### On Ubuntu-1804, libgdbm-compat-dev has older modules that are no longer in libgdbm-dev
         Execute-Command -Command "sudo apt install -y libgdbm-compat-dev"
+
+        ### Python 3.10-3.12 need libcrypt-dev (crypt.h) which is not installed by default on Ubuntu 26.04
+        if ($this.Version -ge "3.10.0" -and $this.Version -lt "3.13.0" -and $this.Platform -match "26\.04") {
+            Execute-Command -Command "sudo apt install -y libcrypt-dev"
+        }
     }
 }


### PR DESCRIPTION
This PR includes a fix for Python 3.10–3.12 builds on Ubuntu 26.04, which fail because crypt.h (libxcrypt) is no longer installed by default.