### PR TITLE
Pass `--only-binary :all:` when upgrading pip

### DIFF
--- a/installers/nix-setup-template.sh
+++ b/installers/nix-setup-template.sh
@@ -54,7 +54,7 @@ export PIP_ROOT_USER_ACTION=ignore
 if ! ./python -c "import pip" 2>/dev/null; then
   ./python -m ensurepip
 fi
-./python -m pip install --upgrade --force-reinstall pip --disable-pip-version-check --no-warn-script-location
+./python -m pip install --only-binary ':all:' --upgrade --force-reinstall pip --disable-pip-version-check --no-warn-script-location
 
 echo "Create complete file"
 touch $PYTHON_TOOLCACHE_VERSION_PATH/$ARCH.complete

--- a/installers/win-setup-template.ps1
+++ b/installers/win-setup-template.ps1
@@ -150,7 +150,7 @@ if ($LASTEXITCODE -ne 0) {
         Throw "Error happened during ensurepip execution"
     }
 }
-cmd.exe /c "$PythonExePath -m pip install --upgrade --force-reinstall pip --no-warn-script-location"
+cmd.exe /c "$PythonExePath -m pip install --only-binary :all: --upgrade --force-reinstall pip --no-warn-script-location"
 if ($LASTEXITCODE -ne 0) {
     Throw "Error happened during pip installation / upgrade"
 }


### PR DESCRIPTION
This would alleviate some of our concerns from https://github.com/actions/setup-python/issues/1346 in a very straightforward way, by preventing possible setup-time code execution, so that a caller's supply chain would be unaffected by setup-python's auto-updated pip unless it is actually invoked.

AFAIK, it can be taken for granted that every valid pip release includes a wheel package. If a pip release included only an sdist, that might be either accidental or malicious, and deserve investigation before being automatically installed to millions of callers.

Disclaimer: I'm not aware of a good way to actually test the integration, esp. windows